### PR TITLE
Loaded and re-saved in QGIS 3.34.10 with Qt 5.15.13 (Windows)

### DIFF
--- a/world.qgs
+++ b/world.qgs
@@ -1,12 +1,12 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="" saveDateTime="2024-09-11T10:23:20" saveUser="jkroeger" saveUserFull="Johannes Kröger" version="3.39.0-Master">
+<qgis saveUserFull="user" saveUser="user" saveDateTime="2024-09-12T14:01:19" version="3.34.10-Prizren" projectname="">
   <homePath path=""/>
   <title></title>
   <transaction mode="Disabled"/>
   <projectFlags set=""/>
   <projectCrs>
     <spatialrefsys nativeFormat="Wkt">
-      <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+      <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
       <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
       <srsid>3452</srsid>
       <srid>4326</srid>
@@ -17,25 +17,12 @@
       <geographicflag>true</geographicflag>
     </spatialrefsys>
   </projectCrs>
-  <verticalCrs>
-    <spatialrefsys nativeFormat="Wkt">
-      <wkt></wkt>
-      <proj4></proj4>
-      <srsid>0</srsid>
-      <srid>0</srid>
-      <authid></authid>
-      <description></description>
-      <projectionacronym></projectionacronym>
-      <ellipsoidacronym></ellipsoidacronym>
-      <geographicflag>false</geographicflag>
-    </spatialrefsys>
-  </verticalCrs>
-  <elevation-shading-renderer combined-method="0" edl-distance="0.5" edl-distance-unit="0" edl-is-active="1" edl-strength="1000" hillshading-is-active="0" hillshading-is-multidirectional="0" hillshading-z-factor="1" is-active="0" light-altitude="45" light-azimuth="315"/>
+  <elevation-shading-renderer light-azimuth="315" is-active="0" combined-method="0" edl-strength="1000" edl-distance-unit="0" hillshading-z-factor="1" hillshading-is-active="0" hillshading-is-multidirectional="0" edl-is-active="1" edl-distance="0.5" light-altitude="45"/>
   <layer-tree-group>
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="World_Map_54e6c9d1_597c_4421_b072_9deaad000f27" legend_exp="" legend_split_behavior="0" name="World Map" patch_size="-1,-1" providerKey="ogr" source="inbuilt:/data/world_map.gpkg|layername=countries">
+    <layer-tree-layer id="World_Map_54e6c9d1_597c_4421_b072_9deaad000f27" name="World Map" expanded="1" checked="Qt::Checked" providerKey="ogr" source="inbuilt:/data/world_map.gpkg|layername=countries" legend_split_behavior="0" patch_size="-1,-1" legend_exp="">
       <customproperties>
         <Option/>
       </customproperties>
@@ -44,14 +31,14 @@
       <item>World_Map_54e6c9d1_597c_4421_b072_9deaad000f27</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings enabled="0" intersection-snapping="0" maxScale="0" minScale="0" mode="2" scaleDependencyMode="0" self-snapping="0" tolerance="12" type="1" unit="1">
+  <snapping-settings tolerance="12" intersection-snapping="0" self-snapping="0" maxScale="0" minScale="0" enabled="0" type="1" unit="1" scaleDependencyMode="0" mode="2">
     <individual-layer-settings>
-      <layer-setting enabled="0" id="World_Map_54e6c9d1_597c_4421_b072_9deaad000f27" maxScale="0" minScale="0" tolerance="12" type="1" units="1"/>
+      <layer-setting id="World_Map_54e6c9d1_597c_4421_b072_9deaad000f27" tolerance="12" maxScale="0" minScale="0" enabled="0" type="1" units="1"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations/>
   <polymorphicRelations/>
-  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+  <mapcanvas name="theMapCanvas" annotationsVisible="1">
     <units>degrees</units>
     <extent>
       <xmin>-188.89500000000001023</xmin>
@@ -62,7 +49,7 @@
     <rotation>0</rotation>
     <destinationsrs>
       <spatialrefsys nativeFormat="Wkt">
-        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -76,15 +63,16 @@
     <rendermaptile>0</rendermaptile>
     <expressionContextScope/>
   </mapcanvas>
+  <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="World Map" open="true" showFeatureCount="0">
+    <legendlayer name="World Map" checked="Qt::Checked" open="true" showFeatureCount="0" drawingOrder="-1">
       <filegroup hidden="false" open="true">
         <legendlayerfile isInOverview="0" layerid="World_Map_54e6c9d1_597c_4421_b072_9deaad000f27" visible="1"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
-  <main-annotation-layer autoRefreshMode="Disabled" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="0" minScale="1e+08" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="annotation">
+  <main-annotation-layer styleCategories="AllStyleCategories" maxScale="0" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" minScale="1e+08" refreshOnNotifyEnabled="0" autoRefreshMode="Disabled" type="annotation" legendPlaceholderImage="" refreshOnNotifyMessage="">
     <id>Annotations_0bc9028a_5503_42f5_b186_0780afc2eb4c</id>
     <datasource></datasource>
     <keywordList>
@@ -93,7 +81,7 @@
     <layername>Annotations</layername>
     <srs>
       <spatialrefsys nativeFormat="Wkt">
-        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -145,19 +133,7 @@
     <paintEffect/>
   </main-annotation-layer>
   <projectlayers>
-    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="0" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
-      <extent>
-        <xmin>-179.90000000000000568</xmin>
-        <ymin>-89.90000000000000568</ymin>
-        <xmax>179.90000000000000568</xmax>
-        <ymax>83.63410000000000366</ymax>
-      </extent>
-      <wgs84extent>
-        <xmin>-179.90000000000000568</xmin>
-        <ymin>-89.90000000000000568</ymin>
-        <xmax>179.90000000000000568</xmax>
-        <ymax>83.63410000000000366</ymax>
-      </wgs84extent>
+    <maplayer autoRefreshMode="Disabled" simplifyMaxScale="1" geometry="Polygon" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" maxScale="0" minScale="0" styleCategories="AllStyleCategories" simplifyDrawingHints="1" autoRefreshTime="0" refreshOnNotifyEnabled="0" legendPlaceholderImage="" simplifyAlgorithm="0" refreshOnNotifyMessage="" type="vector" readOnly="0" symbologyReferenceScale="-1" simplifyDrawingTol="1" wkbType="MultiPolygon">
       <id>World_Map_54e6c9d1_597c_4421_b072_9deaad000f27</id>
       <datasource>inbuilt:/data/world_map.gpkg|layername=countries</datasource>
       <keywordList>
@@ -166,7 +142,7 @@
       <layername>World Map</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
-          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -191,7 +167,7 @@
         <crs>
           <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
-            <proj4></proj4>
+            <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>0</srsid>
             <srid>0</srid>
             <authid></authid>
@@ -219,173 +195,173 @@
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+      <temporal endExpression="" durationUnit="min" limitMode="0" durationField="" enabled="0" startExpression="" fixedDuration="0" startField="" endField="" accumulate="0" mode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+      <elevation extrusion="0" showMarkerSymbolInSurfacePlots="0" zscale="1" binding="Centroid" zoffset="0" type="IndividualFeatures" respectLayerSymbol="1" clamping="Terrain" extrusionEnabled="0" symbology="Line">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+          <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="line" frame_rate="10" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleLine" enabled="1" id="{3cea94f6-051f-496d-9d0b-839df38d2201}" locked="0" pass="0">
+            <layer id="{3cea94f6-051f-496d-9d0b-839df38d2201}" locked="0" class="SimpleLine" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0"/>
-                <Option name="capstyle" type="QString" value="square"/>
-                <Option name="customdash" type="QString" value="5;2"/>
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="customdash_unit" type="QString" value="MM"/>
-                <Option name="dash_pattern_offset" type="QString" value="0"/>
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-                <Option name="draw_inside_polygon" type="QString" value="0"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="line_color" type="QString" value="133,182,111,255,rgb:0.5215686559677124,0.7137255072593689,0.43529412150382996,1"/>
-                <Option name="line_style" type="QString" value="solid"/>
-                <Option name="line_width" type="QString" value="0.6"/>
-                <Option name="line_width_unit" type="QString" value="MM"/>
-                <Option name="offset" type="QString" value="0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="ring_filter" type="QString" value="0"/>
-                <Option name="trim_distance_end" type="QString" value="0"/>
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-                <Option name="trim_distance_start" type="QString" value="0"/>
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-                <Option name="use_custom_dash" type="QString" value="0"/>
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option value="0" name="align_dash_pattern" type="QString"/>
+                <Option value="square" name="capstyle" type="QString"/>
+                <Option value="5;2" name="customdash" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+                <Option value="MM" name="customdash_unit" type="QString"/>
+                <Option value="0" name="dash_pattern_offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+                <Option value="0" name="draw_inside_polygon" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="133,182,111,255" name="line_color" type="QString"/>
+                <Option value="solid" name="line_style" type="QString"/>
+                <Option value="0.6" name="line_width" type="QString"/>
+                <Option value="MM" name="line_width_unit" type="QString"/>
+                <Option value="0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="0" name="ring_filter" type="QString"/>
+                <Option value="0" name="trim_distance_end" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+                <Option value="0" name="trim_distance_start" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+                <Option value="0" name="use_custom_dash" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+          <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="fill" frame_rate="10" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" enabled="1" id="{dfd2bcbb-6aa4-4fff-80f9-fe1249d2478e}" locked="0" pass="0">
+            <layer id="{dfd2bcbb-6aa4-4fff-80f9-fe1249d2478e}" locked="0" class="SimpleFill" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="color" type="QString" value="133,182,111,255,rgb:0.5215686559677124,0.7137255072593689,0.43529412150382996,1"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="95,130,79,255,rgb:0.37254902720451355,0.50980395078659058,0.31091782450675964,1"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0.2"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="style" type="QString" value="solid"/>
+                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+                <Option value="133,182,111,255" name="color" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="95,130,79,255" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0.2" name="outline_width" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="solid" name="style" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+          <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="marker" frame_rate="10" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleMarker" enabled="1" id="{39fe132a-18fd-4d19-bd31-ca6ccbd046ad}" locked="0" pass="0">
+            <layer id="{39fe132a-18fd-4d19-bd31-ca6ccbd046ad}" locked="0" class="SimpleMarker" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0"/>
-                <Option name="cap_style" type="QString" value="square"/>
-                <Option name="color" type="QString" value="133,182,111,255,rgb:0.5215686559677124,0.7137255072593689,0.43529412150382996,1"/>
-                <Option name="horizontal_anchor_point" type="QString" value="1"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="name" type="QString" value="diamond"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="95,130,79,255,rgb:0.37254902720451355,0.50980395078659058,0.31091782450675964,1"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0.2"/>
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="scale_method" type="QString" value="diameter"/>
-                <Option name="size" type="QString" value="3"/>
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="size_unit" type="QString" value="MM"/>
-                <Option name="vertical_anchor_point" type="QString" value="1"/>
+                <Option value="0" name="angle" type="QString"/>
+                <Option value="square" name="cap_style" type="QString"/>
+                <Option value="133,182,111,255" name="color" type="QString"/>
+                <Option value="1" name="horizontal_anchor_point" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="diamond" name="name" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="95,130,79,255" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0.2" name="outline_width" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="diameter" name="scale_method" type="QString"/>
+                <Option value="3" name="size" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+                <Option value="MM" name="size_unit" type="QString"/>
+                <Option value="1" name="vertical_anchor_point" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileMarkerSymbol>
       </elevation>
-      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
         <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+          <symbol alpha="1" name="0" clip_to_extent="1" force_rhr="0" type="fill" frame_rate="10" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" enabled="1" id="{8e38fbfb-3f04-4706-9674-ae6c475fc722}" locked="0" pass="0">
+            <layer id="{8e38fbfb-3f04-4706-9674-ae6c475fc722}" locked="0" class="SimpleFill" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="color" type="QString" value="224,220,202,154,rgb:0.87843137979507446,0.86274510622024536,0.7921568751335144,0.60392159223556519"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="119,116,104,154,rgb:0.46666666865348816,0.45490196347236633,0.40784314274787903,0.60392159223556519"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0.26"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="style" type="QString" value="solid"/>
+                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+                <Option value="224,220,202,154" name="color" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="119,116,104,154" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0.26" name="outline_width" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="solid" name="style" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -393,76 +369,69 @@
         </symbols>
         <rotation/>
         <sizescale/>
-        <data-defined-properties>
-          <Option type="Map">
-            <Option name="name" type="QString" value=""/>
-            <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
-          </Option>
-        </data-defined-properties>
       </renderer-v2>
       <selection mode="Default">
         <selectionColor invalid="1"/>
       </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="dualview/previewExpressions" type="QString" value="NAME"/>
-          <Option name="embeddedWidgets/count" type="QString" value="0"/>
-          <Option name="variableNames"/>
-          <Option name="variableValues"/>
+          <Option value="NAME" name="dualview/previewExpressions" type="QString"/>
+          <Option value="0" name="embeddedWidgets/count" type="QString"/>
+          <Option name="variableNames" type="invalid"/>
+          <Option name="variableValues" type="invalid"/>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties bold="0" description="Cantarell,11,-1,5,400,0,0,0,0,0,0,0,0,0,0,1" italic="0" strikethrough="0" style="" underline="0"/>
-          <attribute color="#000000" colorOpacity="1" field="" label=""/>
+      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+        <DiagramCategory diagramOrientation="Up" showAxis="0" spacing="0" sizeType="MM" opacity="1" backgroundAlpha="255" penAlpha="255" width="15" direction="1" penWidth="0" spacingUnit="MM" backgroundColor="#ffffff" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" height="15" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" spacingUnitScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" maxScaleDenominator="1e+08" rotationOffset="270" minScaleDenominator="0" enabled="0" minimumSize="0" scaleBasedVisibility="0" lineSizeType="MM">
+          <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" italic="0" underline="0" strikethrough="0" style=""/>
+          <attribute field="" colorOpacity="1" color="#000000" label=""/>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="line" frame_rate="10" is_animated="0">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer class="SimpleLine" enabled="1" id="{54b6f760-e6c3-4793-be93-a5815524b2e2}" locked="0" pass="0">
+              <layer id="{54b6f760-e6c3-4793-be93-a5815524b2e2}" locked="0" class="SimpleLine" enabled="1" pass="0">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" type="QString" value="0"/>
-                  <Option name="capstyle" type="QString" value="square"/>
-                  <Option name="customdash" type="QString" value="5;2"/>
-                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="customdash_unit" type="QString" value="MM"/>
-                  <Option name="dash_pattern_offset" type="QString" value="0"/>
-                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-                  <Option name="draw_inside_polygon" type="QString" value="0"/>
-                  <Option name="joinstyle" type="QString" value="bevel"/>
-                  <Option name="line_color" type="QString" value="35,35,35,255,rgb:0.13725490868091583,0.13725490868091583,0.13725490868091583,1"/>
-                  <Option name="line_style" type="QString" value="solid"/>
-                  <Option name="line_width" type="QString" value="0.26"/>
-                  <Option name="line_width_unit" type="QString" value="MM"/>
-                  <Option name="offset" type="QString" value="0"/>
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="offset_unit" type="QString" value="MM"/>
-                  <Option name="ring_filter" type="QString" value="0"/>
-                  <Option name="trim_distance_end" type="QString" value="0"/>
-                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-                  <Option name="trim_distance_start" type="QString" value="0"/>
-                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-                  <Option name="use_custom_dash" type="QString" value="0"/>
-                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                  <Option value="0" name="align_dash_pattern" type="QString"/>
+                  <Option value="square" name="capstyle" type="QString"/>
+                  <Option value="5;2" name="customdash" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="customdash_unit" type="QString"/>
+                  <Option value="0" name="dash_pattern_offset" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+                  <Option value="0" name="draw_inside_polygon" type="QString"/>
+                  <Option value="bevel" name="joinstyle" type="QString"/>
+                  <Option value="35,35,35,255" name="line_color" type="QString"/>
+                  <Option value="solid" name="line_style" type="QString"/>
+                  <Option value="0.26" name="line_width" type="QString"/>
+                  <Option value="MM" name="line_width_unit" type="QString"/>
+                  <Option value="0" name="offset" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="offset_unit" type="QString"/>
+                  <Option value="0" name="ring_filter" type="QString"/>
+                  <Option value="0" name="trim_distance_end" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+                  <Option value="0" name="trim_distance_start" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+                  <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+                  <Option value="0" name="use_custom_dash" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
                 </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value=""/>
+                    <Option value="" name="name" type="QString"/>
                     <Option name="properties"/>
-                    <Option name="type" type="QString" value="collection"/>
+                    <Option value="collection" name="type" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -470,65 +439,65 @@
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
+      <DiagramLayerSettings placement="0" zIndex="0" obstacle="0" priority="0" dist="0" linePlacementFlags="18" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
       <legend showLabelLegend="0" type="default-vector"/>
       <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="NoFlag" name="fid">
+        <field name="fid" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="iso_a2">
+        <field name="iso_a2" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="NAME">
+        <field name="NAME" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="FIPS_10_">
+        <field name="FIPS_10_" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="ISO_A3">
+        <field name="ISO_A3" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="WB_A2">
+        <field name="WB_A2" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="WB_A3">
+        <field name="WB_A3" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
@@ -537,13 +506,13 @@
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="fid" index="0" name=""/>
-        <alias field="iso_a2" index="1" name=""/>
-        <alias field="NAME" index="2" name=""/>
-        <alias field="FIPS_10_" index="3" name=""/>
-        <alias field="ISO_A3" index="4" name=""/>
-        <alias field="WB_A2" index="5" name=""/>
-        <alias field="WB_A3" index="6" name=""/>
+        <alias name="" field="fid" index="0"/>
+        <alias name="" field="iso_a2" index="1"/>
+        <alias name="" field="NAME" index="2"/>
+        <alias name="" field="FIPS_10_" index="3"/>
+        <alias name="" field="ISO_A3" index="4"/>
+        <alias name="" field="WB_A2" index="5"/>
+        <alias name="" field="WB_A3" index="6"/>
       </aliases>
       <splitPolicies>
         <policy field="fid" policy="Duplicate"/>
@@ -554,56 +523,47 @@
         <policy field="WB_A2" policy="Duplicate"/>
         <policy field="WB_A3" policy="Duplicate"/>
       </splitPolicies>
-      <duplicatePolicies>
-        <policy field="fid" policy="Duplicate"/>
-        <policy field="iso_a2" policy="Duplicate"/>
-        <policy field="NAME" policy="Duplicate"/>
-        <policy field="FIPS_10_" policy="Duplicate"/>
-        <policy field="ISO_A3" policy="Duplicate"/>
-        <policy field="WB_A2" policy="Duplicate"/>
-        <policy field="WB_A3" policy="Duplicate"/>
-      </duplicatePolicies>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="fid"/>
-        <default applyOnUpdate="0" expression="" field="iso_a2"/>
-        <default applyOnUpdate="0" expression="" field="NAME"/>
-        <default applyOnUpdate="0" expression="" field="FIPS_10_"/>
-        <default applyOnUpdate="0" expression="" field="ISO_A3"/>
-        <default applyOnUpdate="0" expression="" field="WB_A2"/>
-        <default applyOnUpdate="0" expression="" field="WB_A3"/>
+        <default field="fid" expression="" applyOnUpdate="0"/>
+        <default field="iso_a2" expression="" applyOnUpdate="0"/>
+        <default field="NAME" expression="" applyOnUpdate="0"/>
+        <default field="FIPS_10_" expression="" applyOnUpdate="0"/>
+        <default field="ISO_A3" expression="" applyOnUpdate="0"/>
+        <default field="WB_A2" expression="" applyOnUpdate="0"/>
+        <default field="WB_A3" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"/>
-        <constraint constraints="0" exp_strength="0" field="iso_a2" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="NAME" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="FIPS_10_" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="ISO_A3" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="WB_A2" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="WB_A3" notnull_strength="0" unique_strength="0"/>
+        <constraint unique_strength="1" field="fid" notnull_strength="1" exp_strength="0" constraints="3"/>
+        <constraint unique_strength="0" field="iso_a2" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="NAME" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="FIPS_10_" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="ISO_A3" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="WB_A2" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="WB_A3" notnull_strength="0" exp_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="fid"/>
-        <constraint desc="" exp="" field="iso_a2"/>
-        <constraint desc="" exp="" field="NAME"/>
-        <constraint desc="" exp="" field="FIPS_10_"/>
-        <constraint desc="" exp="" field="ISO_A3"/>
-        <constraint desc="" exp="" field="WB_A2"/>
-        <constraint desc="" exp="" field="WB_A3"/>
+        <constraint field="fid" exp="" desc=""/>
+        <constraint field="iso_a2" exp="" desc=""/>
+        <constraint field="NAME" exp="" desc=""/>
+        <constraint field="FIPS_10_" exp="" desc=""/>
+        <constraint field="ISO_A3" exp="" desc=""/>
+        <constraint field="WB_A2" exp="" desc=""/>
+        <constraint field="WB_A3" exp="" desc=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
       </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns>
-          <column hidden="0" name="NAME" type="field" width="-1"/>
-          <column hidden="0" name="FIPS_10_" type="field" width="-1"/>
-          <column hidden="0" name="ISO_A3" type="field" width="-1"/>
-          <column hidden="0" name="WB_A2" type="field" width="-1"/>
-          <column hidden="0" name="WB_A3" type="field" width="-1"/>
-          <column hidden="1" type="actions" width="-1"/>
-          <column hidden="0" name="fid" type="field" width="-1"/>
-          <column hidden="0" name="iso_a2" type="field" width="-1"/>
+          <column name="NAME" hidden="0" width="-1" type="field"/>
+          <column name="FIPS_10_" hidden="0" width="-1" type="field"/>
+          <column name="ISO_A3" hidden="0" width="-1" type="field"/>
+          <column name="WB_A2" hidden="0" width="-1" type="field"/>
+          <column name="WB_A3" hidden="0" width="-1" type="field"/>
+          <column hidden="1" width="-1" type="actions"/>
+          <column name="fid" hidden="0" width="-1" type="field"/>
+          <column name="iso_a2" hidden="0" width="-1" type="field"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -635,200 +595,200 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="ABBREV"/>
-        <field editable="1" name="ABBREV_LEN"/>
-        <field editable="1" name="ADM0_A3"/>
-        <field editable="1" name="ADM0_A3_IS"/>
-        <field editable="1" name="ADM0_A3_UN"/>
-        <field editable="1" name="ADM0_A3_US"/>
-        <field editable="1" name="ADM0_A3_WB"/>
-        <field editable="1" name="ADM0_DIF"/>
-        <field editable="1" name="ADMIN"/>
-        <field editable="1" name="BRK_A3"/>
-        <field editable="1" name="BRK_DIFF"/>
-        <field editable="1" name="BRK_GROUP"/>
-        <field editable="1" name="BRK_NAME"/>
-        <field editable="1" name="CONTINENT"/>
-        <field editable="1" name="ECONOMY"/>
-        <field editable="1" name="FIPS_10_"/>
-        <field editable="1" name="FORMAL_EN"/>
-        <field editable="1" name="FORMAL_FR"/>
-        <field editable="1" name="GDP_MD_EST"/>
-        <field editable="1" name="GDP_YEAR"/>
-        <field editable="1" name="GEOUNIT"/>
-        <field editable="1" name="GEOU_DIF"/>
-        <field editable="1" name="GU_A3"/>
-        <field editable="1" name="HOMEPART"/>
-        <field editable="1" name="INCOME_GRP"/>
-        <field editable="1" name="ISO_A2"/>
-        <field editable="1" name="ISO_A3"/>
-        <field editable="1" name="ISO_A3_EH"/>
-        <field editable="1" name="ISO_N3"/>
-        <field editable="1" name="LABELRANK"/>
-        <field editable="1" name="LASTCENSUS"/>
-        <field editable="1" name="LEVEL"/>
-        <field editable="1" name="LONG_LEN"/>
-        <field editable="1" name="MAPCOLOR13"/>
-        <field editable="1" name="MAPCOLOR7"/>
-        <field editable="1" name="MAPCOLOR8"/>
-        <field editable="1" name="MAPCOLOR9"/>
-        <field editable="1" name="MAX_LABEL"/>
-        <field editable="1" name="MIN_LABEL"/>
-        <field editable="1" name="MIN_ZOOM"/>
-        <field editable="1" name="NAME"/>
-        <field editable="1" name="NAME_ALT"/>
-        <field editable="1" name="NAME_AR"/>
-        <field editable="1" name="NAME_BN"/>
-        <field editable="1" name="NAME_CIAWF"/>
-        <field editable="1" name="NAME_DE"/>
-        <field editable="1" name="NAME_EL"/>
-        <field editable="1" name="NAME_EN"/>
-        <field editable="1" name="NAME_ES"/>
-        <field editable="1" name="NAME_FR"/>
-        <field editable="1" name="NAME_HI"/>
-        <field editable="1" name="NAME_HU"/>
-        <field editable="1" name="NAME_ID"/>
-        <field editable="1" name="NAME_IT"/>
-        <field editable="1" name="NAME_JA"/>
-        <field editable="1" name="NAME_KO"/>
-        <field editable="1" name="NAME_LEN"/>
-        <field editable="1" name="NAME_LONG"/>
-        <field editable="1" name="NAME_NL"/>
-        <field editable="1" name="NAME_PL"/>
-        <field editable="1" name="NAME_PT"/>
-        <field editable="1" name="NAME_RU"/>
-        <field editable="1" name="NAME_SORT"/>
-        <field editable="1" name="NAME_SV"/>
-        <field editable="1" name="NAME_TR"/>
-        <field editable="1" name="NAME_VI"/>
-        <field editable="1" name="NAME_ZH"/>
-        <field editable="1" name="NE_ID"/>
-        <field editable="1" name="NOTE_ADM0"/>
-        <field editable="1" name="NOTE_BRK"/>
-        <field editable="1" name="POP_EST"/>
-        <field editable="1" name="POP_RANK"/>
-        <field editable="1" name="POP_YEAR"/>
-        <field editable="1" name="POSTAL"/>
-        <field editable="1" name="REGION_UN"/>
-        <field editable="1" name="REGION_WB"/>
-        <field editable="1" name="SOVEREIGNT"/>
-        <field editable="1" name="SOV_A3"/>
-        <field editable="1" name="SUBREGION"/>
-        <field editable="1" name="SUBUNIT"/>
-        <field editable="1" name="SU_A3"/>
-        <field editable="1" name="SU_DIF"/>
-        <field editable="1" name="TINY"/>
-        <field editable="1" name="TYPE"/>
-        <field editable="1" name="UN_A3"/>
-        <field editable="1" name="WB_A2"/>
-        <field editable="1" name="WB_A3"/>
-        <field editable="1" name="WIKIDATAID"/>
-        <field editable="1" name="WIKIPEDIA"/>
-        <field editable="1" name="WOE_ID"/>
-        <field editable="1" name="WOE_ID_EH"/>
-        <field editable="1" name="WOE_NOTE"/>
-        <field editable="1" name="featurecla"/>
-        <field editable="1" name="fid"/>
-        <field editable="1" name="iso_a2"/>
-        <field editable="1" name="scalerank"/>
+        <field name="ABBREV" editable="1"/>
+        <field name="ABBREV_LEN" editable="1"/>
+        <field name="ADM0_A3" editable="1"/>
+        <field name="ADM0_A3_IS" editable="1"/>
+        <field name="ADM0_A3_UN" editable="1"/>
+        <field name="ADM0_A3_US" editable="1"/>
+        <field name="ADM0_A3_WB" editable="1"/>
+        <field name="ADM0_DIF" editable="1"/>
+        <field name="ADMIN" editable="1"/>
+        <field name="BRK_A3" editable="1"/>
+        <field name="BRK_DIFF" editable="1"/>
+        <field name="BRK_GROUP" editable="1"/>
+        <field name="BRK_NAME" editable="1"/>
+        <field name="CONTINENT" editable="1"/>
+        <field name="ECONOMY" editable="1"/>
+        <field name="FIPS_10_" editable="1"/>
+        <field name="FORMAL_EN" editable="1"/>
+        <field name="FORMAL_FR" editable="1"/>
+        <field name="GDP_MD_EST" editable="1"/>
+        <field name="GDP_YEAR" editable="1"/>
+        <field name="GEOUNIT" editable="1"/>
+        <field name="GEOU_DIF" editable="1"/>
+        <field name="GU_A3" editable="1"/>
+        <field name="HOMEPART" editable="1"/>
+        <field name="INCOME_GRP" editable="1"/>
+        <field name="ISO_A2" editable="1"/>
+        <field name="ISO_A3" editable="1"/>
+        <field name="ISO_A3_EH" editable="1"/>
+        <field name="ISO_N3" editable="1"/>
+        <field name="LABELRANK" editable="1"/>
+        <field name="LASTCENSUS" editable="1"/>
+        <field name="LEVEL" editable="1"/>
+        <field name="LONG_LEN" editable="1"/>
+        <field name="MAPCOLOR13" editable="1"/>
+        <field name="MAPCOLOR7" editable="1"/>
+        <field name="MAPCOLOR8" editable="1"/>
+        <field name="MAPCOLOR9" editable="1"/>
+        <field name="MAX_LABEL" editable="1"/>
+        <field name="MIN_LABEL" editable="1"/>
+        <field name="MIN_ZOOM" editable="1"/>
+        <field name="NAME" editable="1"/>
+        <field name="NAME_ALT" editable="1"/>
+        <field name="NAME_AR" editable="1"/>
+        <field name="NAME_BN" editable="1"/>
+        <field name="NAME_CIAWF" editable="1"/>
+        <field name="NAME_DE" editable="1"/>
+        <field name="NAME_EL" editable="1"/>
+        <field name="NAME_EN" editable="1"/>
+        <field name="NAME_ES" editable="1"/>
+        <field name="NAME_FR" editable="1"/>
+        <field name="NAME_HI" editable="1"/>
+        <field name="NAME_HU" editable="1"/>
+        <field name="NAME_ID" editable="1"/>
+        <field name="NAME_IT" editable="1"/>
+        <field name="NAME_JA" editable="1"/>
+        <field name="NAME_KO" editable="1"/>
+        <field name="NAME_LEN" editable="1"/>
+        <field name="NAME_LONG" editable="1"/>
+        <field name="NAME_NL" editable="1"/>
+        <field name="NAME_PL" editable="1"/>
+        <field name="NAME_PT" editable="1"/>
+        <field name="NAME_RU" editable="1"/>
+        <field name="NAME_SORT" editable="1"/>
+        <field name="NAME_SV" editable="1"/>
+        <field name="NAME_TR" editable="1"/>
+        <field name="NAME_VI" editable="1"/>
+        <field name="NAME_ZH" editable="1"/>
+        <field name="NE_ID" editable="1"/>
+        <field name="NOTE_ADM0" editable="1"/>
+        <field name="NOTE_BRK" editable="1"/>
+        <field name="POP_EST" editable="1"/>
+        <field name="POP_RANK" editable="1"/>
+        <field name="POP_YEAR" editable="1"/>
+        <field name="POSTAL" editable="1"/>
+        <field name="REGION_UN" editable="1"/>
+        <field name="REGION_WB" editable="1"/>
+        <field name="SOVEREIGNT" editable="1"/>
+        <field name="SOV_A3" editable="1"/>
+        <field name="SUBREGION" editable="1"/>
+        <field name="SUBUNIT" editable="1"/>
+        <field name="SU_A3" editable="1"/>
+        <field name="SU_DIF" editable="1"/>
+        <field name="TINY" editable="1"/>
+        <field name="TYPE" editable="1"/>
+        <field name="UN_A3" editable="1"/>
+        <field name="WB_A2" editable="1"/>
+        <field name="WB_A3" editable="1"/>
+        <field name="WIKIDATAID" editable="1"/>
+        <field name="WIKIPEDIA" editable="1"/>
+        <field name="WOE_ID" editable="1"/>
+        <field name="WOE_ID_EH" editable="1"/>
+        <field name="WOE_NOTE" editable="1"/>
+        <field name="featurecla" editable="1"/>
+        <field name="fid" editable="1"/>
+        <field name="iso_a2" editable="1"/>
+        <field name="scalerank" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="ABBREV"/>
-        <field labelOnTop="0" name="ABBREV_LEN"/>
-        <field labelOnTop="0" name="ADM0_A3"/>
-        <field labelOnTop="0" name="ADM0_A3_IS"/>
-        <field labelOnTop="0" name="ADM0_A3_UN"/>
-        <field labelOnTop="0" name="ADM0_A3_US"/>
-        <field labelOnTop="0" name="ADM0_A3_WB"/>
-        <field labelOnTop="0" name="ADM0_DIF"/>
-        <field labelOnTop="0" name="ADMIN"/>
-        <field labelOnTop="0" name="BRK_A3"/>
-        <field labelOnTop="0" name="BRK_DIFF"/>
-        <field labelOnTop="0" name="BRK_GROUP"/>
-        <field labelOnTop="0" name="BRK_NAME"/>
-        <field labelOnTop="0" name="CONTINENT"/>
-        <field labelOnTop="0" name="ECONOMY"/>
-        <field labelOnTop="0" name="FIPS_10_"/>
-        <field labelOnTop="0" name="FORMAL_EN"/>
-        <field labelOnTop="0" name="FORMAL_FR"/>
-        <field labelOnTop="0" name="GDP_MD_EST"/>
-        <field labelOnTop="0" name="GDP_YEAR"/>
-        <field labelOnTop="0" name="GEOUNIT"/>
-        <field labelOnTop="0" name="GEOU_DIF"/>
-        <field labelOnTop="0" name="GU_A3"/>
-        <field labelOnTop="0" name="HOMEPART"/>
-        <field labelOnTop="0" name="INCOME_GRP"/>
-        <field labelOnTop="0" name="ISO_A2"/>
-        <field labelOnTop="0" name="ISO_A3"/>
-        <field labelOnTop="0" name="ISO_A3_EH"/>
-        <field labelOnTop="0" name="ISO_N3"/>
-        <field labelOnTop="0" name="LABELRANK"/>
-        <field labelOnTop="0" name="LASTCENSUS"/>
-        <field labelOnTop="0" name="LEVEL"/>
-        <field labelOnTop="0" name="LONG_LEN"/>
-        <field labelOnTop="0" name="MAPCOLOR13"/>
-        <field labelOnTop="0" name="MAPCOLOR7"/>
-        <field labelOnTop="0" name="MAPCOLOR8"/>
-        <field labelOnTop="0" name="MAPCOLOR9"/>
-        <field labelOnTop="0" name="MAX_LABEL"/>
-        <field labelOnTop="0" name="MIN_LABEL"/>
-        <field labelOnTop="0" name="MIN_ZOOM"/>
-        <field labelOnTop="0" name="NAME"/>
-        <field labelOnTop="0" name="NAME_ALT"/>
-        <field labelOnTop="0" name="NAME_AR"/>
-        <field labelOnTop="0" name="NAME_BN"/>
-        <field labelOnTop="0" name="NAME_CIAWF"/>
-        <field labelOnTop="0" name="NAME_DE"/>
-        <field labelOnTop="0" name="NAME_EL"/>
-        <field labelOnTop="0" name="NAME_EN"/>
-        <field labelOnTop="0" name="NAME_ES"/>
-        <field labelOnTop="0" name="NAME_FR"/>
-        <field labelOnTop="0" name="NAME_HI"/>
-        <field labelOnTop="0" name="NAME_HU"/>
-        <field labelOnTop="0" name="NAME_ID"/>
-        <field labelOnTop="0" name="NAME_IT"/>
-        <field labelOnTop="0" name="NAME_JA"/>
-        <field labelOnTop="0" name="NAME_KO"/>
-        <field labelOnTop="0" name="NAME_LEN"/>
-        <field labelOnTop="0" name="NAME_LONG"/>
-        <field labelOnTop="0" name="NAME_NL"/>
-        <field labelOnTop="0" name="NAME_PL"/>
-        <field labelOnTop="0" name="NAME_PT"/>
-        <field labelOnTop="0" name="NAME_RU"/>
-        <field labelOnTop="0" name="NAME_SORT"/>
-        <field labelOnTop="0" name="NAME_SV"/>
-        <field labelOnTop="0" name="NAME_TR"/>
-        <field labelOnTop="0" name="NAME_VI"/>
-        <field labelOnTop="0" name="NAME_ZH"/>
-        <field labelOnTop="0" name="NE_ID"/>
-        <field labelOnTop="0" name="NOTE_ADM0"/>
-        <field labelOnTop="0" name="NOTE_BRK"/>
-        <field labelOnTop="0" name="POP_EST"/>
-        <field labelOnTop="0" name="POP_RANK"/>
-        <field labelOnTop="0" name="POP_YEAR"/>
-        <field labelOnTop="0" name="POSTAL"/>
-        <field labelOnTop="0" name="REGION_UN"/>
-        <field labelOnTop="0" name="REGION_WB"/>
-        <field labelOnTop="0" name="SOVEREIGNT"/>
-        <field labelOnTop="0" name="SOV_A3"/>
-        <field labelOnTop="0" name="SUBREGION"/>
-        <field labelOnTop="0" name="SUBUNIT"/>
-        <field labelOnTop="0" name="SU_A3"/>
-        <field labelOnTop="0" name="SU_DIF"/>
-        <field labelOnTop="0" name="TINY"/>
-        <field labelOnTop="0" name="TYPE"/>
-        <field labelOnTop="0" name="UN_A3"/>
-        <field labelOnTop="0" name="WB_A2"/>
-        <field labelOnTop="0" name="WB_A3"/>
-        <field labelOnTop="0" name="WIKIDATAID"/>
-        <field labelOnTop="0" name="WIKIPEDIA"/>
-        <field labelOnTop="0" name="WOE_ID"/>
-        <field labelOnTop="0" name="WOE_ID_EH"/>
-        <field labelOnTop="0" name="WOE_NOTE"/>
-        <field labelOnTop="0" name="featurecla"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="iso_a2"/>
-        <field labelOnTop="0" name="scalerank"/>
+        <field name="ABBREV" labelOnTop="0"/>
+        <field name="ABBREV_LEN" labelOnTop="0"/>
+        <field name="ADM0_A3" labelOnTop="0"/>
+        <field name="ADM0_A3_IS" labelOnTop="0"/>
+        <field name="ADM0_A3_UN" labelOnTop="0"/>
+        <field name="ADM0_A3_US" labelOnTop="0"/>
+        <field name="ADM0_A3_WB" labelOnTop="0"/>
+        <field name="ADM0_DIF" labelOnTop="0"/>
+        <field name="ADMIN" labelOnTop="0"/>
+        <field name="BRK_A3" labelOnTop="0"/>
+        <field name="BRK_DIFF" labelOnTop="0"/>
+        <field name="BRK_GROUP" labelOnTop="0"/>
+        <field name="BRK_NAME" labelOnTop="0"/>
+        <field name="CONTINENT" labelOnTop="0"/>
+        <field name="ECONOMY" labelOnTop="0"/>
+        <field name="FIPS_10_" labelOnTop="0"/>
+        <field name="FORMAL_EN" labelOnTop="0"/>
+        <field name="FORMAL_FR" labelOnTop="0"/>
+        <field name="GDP_MD_EST" labelOnTop="0"/>
+        <field name="GDP_YEAR" labelOnTop="0"/>
+        <field name="GEOUNIT" labelOnTop="0"/>
+        <field name="GEOU_DIF" labelOnTop="0"/>
+        <field name="GU_A3" labelOnTop="0"/>
+        <field name="HOMEPART" labelOnTop="0"/>
+        <field name="INCOME_GRP" labelOnTop="0"/>
+        <field name="ISO_A2" labelOnTop="0"/>
+        <field name="ISO_A3" labelOnTop="0"/>
+        <field name="ISO_A3_EH" labelOnTop="0"/>
+        <field name="ISO_N3" labelOnTop="0"/>
+        <field name="LABELRANK" labelOnTop="0"/>
+        <field name="LASTCENSUS" labelOnTop="0"/>
+        <field name="LEVEL" labelOnTop="0"/>
+        <field name="LONG_LEN" labelOnTop="0"/>
+        <field name="MAPCOLOR13" labelOnTop="0"/>
+        <field name="MAPCOLOR7" labelOnTop="0"/>
+        <field name="MAPCOLOR8" labelOnTop="0"/>
+        <field name="MAPCOLOR9" labelOnTop="0"/>
+        <field name="MAX_LABEL" labelOnTop="0"/>
+        <field name="MIN_LABEL" labelOnTop="0"/>
+        <field name="MIN_ZOOM" labelOnTop="0"/>
+        <field name="NAME" labelOnTop="0"/>
+        <field name="NAME_ALT" labelOnTop="0"/>
+        <field name="NAME_AR" labelOnTop="0"/>
+        <field name="NAME_BN" labelOnTop="0"/>
+        <field name="NAME_CIAWF" labelOnTop="0"/>
+        <field name="NAME_DE" labelOnTop="0"/>
+        <field name="NAME_EL" labelOnTop="0"/>
+        <field name="NAME_EN" labelOnTop="0"/>
+        <field name="NAME_ES" labelOnTop="0"/>
+        <field name="NAME_FR" labelOnTop="0"/>
+        <field name="NAME_HI" labelOnTop="0"/>
+        <field name="NAME_HU" labelOnTop="0"/>
+        <field name="NAME_ID" labelOnTop="0"/>
+        <field name="NAME_IT" labelOnTop="0"/>
+        <field name="NAME_JA" labelOnTop="0"/>
+        <field name="NAME_KO" labelOnTop="0"/>
+        <field name="NAME_LEN" labelOnTop="0"/>
+        <field name="NAME_LONG" labelOnTop="0"/>
+        <field name="NAME_NL" labelOnTop="0"/>
+        <field name="NAME_PL" labelOnTop="0"/>
+        <field name="NAME_PT" labelOnTop="0"/>
+        <field name="NAME_RU" labelOnTop="0"/>
+        <field name="NAME_SORT" labelOnTop="0"/>
+        <field name="NAME_SV" labelOnTop="0"/>
+        <field name="NAME_TR" labelOnTop="0"/>
+        <field name="NAME_VI" labelOnTop="0"/>
+        <field name="NAME_ZH" labelOnTop="0"/>
+        <field name="NE_ID" labelOnTop="0"/>
+        <field name="NOTE_ADM0" labelOnTop="0"/>
+        <field name="NOTE_BRK" labelOnTop="0"/>
+        <field name="POP_EST" labelOnTop="0"/>
+        <field name="POP_RANK" labelOnTop="0"/>
+        <field name="POP_YEAR" labelOnTop="0"/>
+        <field name="POSTAL" labelOnTop="0"/>
+        <field name="REGION_UN" labelOnTop="0"/>
+        <field name="REGION_WB" labelOnTop="0"/>
+        <field name="SOVEREIGNT" labelOnTop="0"/>
+        <field name="SOV_A3" labelOnTop="0"/>
+        <field name="SUBREGION" labelOnTop="0"/>
+        <field name="SUBUNIT" labelOnTop="0"/>
+        <field name="SU_A3" labelOnTop="0"/>
+        <field name="SU_DIF" labelOnTop="0"/>
+        <field name="TINY" labelOnTop="0"/>
+        <field name="TYPE" labelOnTop="0"/>
+        <field name="UN_A3" labelOnTop="0"/>
+        <field name="WB_A2" labelOnTop="0"/>
+        <field name="WB_A3" labelOnTop="0"/>
+        <field name="WIKIDATAID" labelOnTop="0"/>
+        <field name="WIKIPEDIA" labelOnTop="0"/>
+        <field name="WOE_ID" labelOnTop="0"/>
+        <field name="WOE_ID_EH" labelOnTop="0"/>
+        <field name="WOE_NOTE" labelOnTop="0"/>
+        <field name="featurecla" labelOnTop="0"/>
+        <field name="fid" labelOnTop="0"/>
+        <field name="iso_a2" labelOnTop="0"/>
+        <field name="scalerank" labelOnTop="0"/>
       </labelOnTop>
       <reuseLastValue/>
       <dataDefinedFieldProperties/>
@@ -840,7 +800,6 @@ def my_form_open(dialog, layer, feature):
   <layerorder>
     <layer id="World_Map_54e6c9d1_597c_4421_b072_9deaad000f27"/>
   </layerorder>
-  <labelEngineSettings/>
   <properties>
     <Digitizing>
       <AvoidIntersectionsMode type="int">0</AvoidIntersectionsMode>
@@ -876,7 +835,7 @@ def my_form_open(dialog, layer, feature):
       <ShowingCandidates type="bool">false</ShowingCandidates>
       <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
       <TextFormat type="int">0</TextFormat>
-      <UnplacedColor type="QString">255,0,0,255,rgb:1,0,0,1</UnplacedColor>
+      <UnplacedColor type="QString">255,0,0,255</UnplacedColor>
     </PAL>
     <Paths>
       <Absolute type="bool">false</Absolute>
@@ -891,9 +850,9 @@ def my_form_open(dialog, layer, feature):
   </properties>
   <dataDefinedServerProperties>
     <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
     </Option>
   </dataDefinedServerProperties>
   <visibility-presets/>
@@ -907,7 +866,7 @@ def my_form_open(dialog, layer, feature):
     <abstract></abstract>
     <links/>
     <dates>
-      <date type="Created" value="2024-09-11T10:17:28"/>
+      <date value="2024-09-11T10:17:28" type="Created"/>
     </dates>
     <author>Johannes Kröger</author>
     <creation>2024-09-11T10:17:28</creation>
@@ -919,9 +878,9 @@ def my_form_open(dialog, layer, feature):
   <Sensors/>
   <ProjectViewSettings UseProjectScales="0" rotation="0">
     <Scales/>
-    <DefaultViewExtent xmax="188.89500000000001023" xmin="-188.89500000000001023" ymax="88.79114351145040018" ymin="-95.057043511450388">
+    <DefaultViewExtent ymin="-154.09197354570636662" ymax="147.82607354570637881" xmin="-188.89500000000001023" xmax="188.89500000000001023">
       <spatialrefsys nativeFormat="Wkt">
-        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -933,46 +892,46 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
-  <ProjectStyleSettings DefaultSymbolOpacity="1" RandomizeDefaultSymbolColor="1" colorModel="Rgb" iccProfileId="attachment:///" projectStyleId="attachment:///tDxwMX_styles.db">
+  <ProjectStyleSettings DefaultSymbolOpacity="1" projectStyleId="attachment:///OaTWxi_styles.db" RandomizeDefaultSymbolColor="1">
     <databases/>
   </ProjectStyleSettings>
-  <ProjectTimeSettings cumulativeTemporalRange="0" frameRate="1" timeStep="1" timeStepUnit="h" totalMovieFrames="100"/>
-  <ElevationProperties FilterInvertSlider="0">
+  <ProjectTimeSettings timeStep="1" frameRate="1" timeStepUnit="h" cumulativeTemporalRange="0"/>
+  <ElevationProperties>
     <terrainProvider type="flat">
-      <TerrainProvider offset="0" scale="1"/>
+      <TerrainProvider scale="1" offset="0"/>
     </terrainProvider>
   </ElevationProperties>
   <ProjectDisplaySettings CoordinateAxisOrder="Default" CoordinateType="MapCrs">
     <BearingFormat id="bearing">
       <Option type="Map">
         <Option name="decimal_separator" type="invalid"/>
-        <Option name="decimals" type="int" value="6"/>
-        <Option name="direction_format" type="int" value="0"/>
-        <Option name="rounding_type" type="int" value="0"/>
-        <Option name="show_plus" type="bool" value="false"/>
-        <Option name="show_thousand_separator" type="bool" value="true"/>
-        <Option name="show_trailing_zeros" type="bool" value="false"/>
+        <Option value="6" name="decimals" type="int"/>
+        <Option value="0" name="direction_format" type="int"/>
+        <Option value="0" name="rounding_type" type="int"/>
+        <Option value="false" name="show_plus" type="bool"/>
+        <Option value="true" name="show_thousand_separator" type="bool"/>
+        <Option value="false" name="show_trailing_zeros" type="bool"/>
         <Option name="thousand_separator" type="invalid"/>
       </Option>
     </BearingFormat>
     <GeographicCoordinateFormat id="geographiccoordinate">
       <Option type="Map">
-        <Option name="angle_format" type="QString" value="DecimalDegrees"/>
+        <Option value="DecimalDegrees" name="angle_format" type="QString"/>
         <Option name="decimal_separator" type="invalid"/>
-        <Option name="decimals" type="int" value="6"/>
-        <Option name="rounding_type" type="int" value="0"/>
-        <Option name="show_leading_degree_zeros" type="bool" value="false"/>
-        <Option name="show_leading_zeros" type="bool" value="false"/>
-        <Option name="show_plus" type="bool" value="false"/>
-        <Option name="show_suffix" type="bool" value="false"/>
-        <Option name="show_thousand_separator" type="bool" value="true"/>
-        <Option name="show_trailing_zeros" type="bool" value="false"/>
+        <Option value="6" name="decimals" type="int"/>
+        <Option value="0" name="rounding_type" type="int"/>
+        <Option value="false" name="show_leading_degree_zeros" type="bool"/>
+        <Option value="false" name="show_leading_zeros" type="bool"/>
+        <Option value="false" name="show_plus" type="bool"/>
+        <Option value="false" name="show_suffix" type="bool"/>
+        <Option value="true" name="show_thousand_separator" type="bool"/>
+        <Option value="false" name="show_trailing_zeros" type="bool"/>
         <Option name="thousand_separator" type="invalid"/>
       </Option>
     </GeographicCoordinateFormat>
     <CoordinateCustomCrs>
       <spatialrefsys nativeFormat="Wkt">
-        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -984,7 +943,7 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings autoAddTrackVertices="0" autoCommitFeatures="0" destinationFollowsActiveLayer="1" destinationLayer="World_Map_54e6c9d1_597c_4421_b072_9deaad000f27" destinationLayerName="World Map" destinationLayerProvider="ogr" destinationLayerSource="/home/jkroeger/dev/cpp/QGIS/build/output/data/resources/data/world_map.gpkg|layername=countries">
+  <ProjectGpsSettings autoCommitFeatures="0" destinationFollowsActiveLayer="1" destinationLayerName="World Map" autoAddTrackVertices="0" destinationLayerProvider="ogr" destinationLayer="World_Map_54e6c9d1_597c_4421_b072_9deaad000f27" destinationLayerSource="C:/Users/user/Desktop/apps/qgis-ltr/./resources/data/world_map.gpkg|layername=countries">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>

--- a/world.qlr
+++ b/world.qlr
@@ -1,17 +1,17 @@
 <!DOCTYPE qgis-layer-definition>
 <qlr>
-  <layer-tree-group checked="Qt::Checked" expanded="1" groupLayer="" name="">
+  <layer-tree-group name="" expanded="1" groupLayer="" checked="Qt::Checked">
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="World_Map_396c2ea4_3171_495c_bed5_0728d66e66b4" legend_exp="" legend_split_behavior="0" name="World Map" patch_size="-1,-1" providerKey="ogr" source="inbuilt:/data/world_map.gpkg|layername=countries">
+    <layer-tree-layer id="World_Map_58104f41_d9a0_4e87_8c19_9f0f6e25461b" name="World Map" expanded="1" checked="Qt::Checked" providerKey="ogr" source="inbuilt:/data/world_map.gpkg|layername=countries" legend_split_behavior="0" patch_size="-1,-1" legend_exp="">
       <customproperties>
         <Option/>
       </customproperties>
     </layer-tree-layer>
   </layer-tree-group>
   <maplayers>
-    <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="0" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
+    <maplayer autoRefreshMode="Disabled" simplifyMaxScale="1" geometry="Polygon" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" maxScale="0" minScale="0" styleCategories="AllStyleCategories" simplifyDrawingHints="1" autoRefreshTime="0" refreshOnNotifyEnabled="0" legendPlaceholderImage="" simplifyAlgorithm="0" refreshOnNotifyMessage="" type="vector" readOnly="0" symbologyReferenceScale="-1" simplifyDrawingTol="1" wkbType="MultiPolygon">
       <extent>
         <xmin>-179.90000000000000568</xmin>
         <ymin>-89.90000000000000568</ymin>
@@ -24,7 +24,7 @@
         <xmax>179.90000000000000568</xmax>
         <ymax>83.63410000000000366</ymax>
       </wgs84extent>
-      <id>World_Map_396c2ea4_3171_495c_bed5_0728d66e66b4</id>
+      <id>World_Map_58104f41_d9a0_4e87_8c19_9f0f6e25461b</id>
       <datasource>inbuilt:/data/world_map.gpkg|layername=countries</datasource>
       <keywordList>
         <value></value>
@@ -32,7 +32,7 @@
       <layername>World Map</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
-          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -57,7 +57,7 @@
         <crs>
           <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
-            <proj4></proj4>
+            <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>0</srsid>
             <srid>0</srid>
             <authid></authid>
@@ -85,173 +85,173 @@
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+      <temporal endExpression="" durationUnit="min" limitMode="0" durationField="" enabled="0" startExpression="" fixedDuration="0" startField="" endField="" accumulate="0" mode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+      <elevation extrusion="0" showMarkerSymbolInSurfacePlots="0" zscale="1" binding="Centroid" zoffset="0" type="IndividualFeatures" respectLayerSymbol="1" clamping="Terrain" extrusionEnabled="0" symbology="Line">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+          <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="line" frame_rate="10" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleLine" enabled="1" id="{a30db034-3641-4edb-8ca7-fc6f8595ac83}" locked="0" pass="0">
+            <layer id="{a30db034-3641-4edb-8ca7-fc6f8595ac83}" locked="0" class="SimpleLine" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0"/>
-                <Option name="capstyle" type="QString" value="square"/>
-                <Option name="customdash" type="QString" value="5;2"/>
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="customdash_unit" type="QString" value="MM"/>
-                <Option name="dash_pattern_offset" type="QString" value="0"/>
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-                <Option name="draw_inside_polygon" type="QString" value="0"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="line_color" type="QString" value="141,90,153,255,rgb:0.55294120311737061,0.35294118523597717,0.60000002384185791,1"/>
-                <Option name="line_style" type="QString" value="solid"/>
-                <Option name="line_width" type="QString" value="0.6"/>
-                <Option name="line_width_unit" type="QString" value="MM"/>
-                <Option name="offset" type="QString" value="0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="ring_filter" type="QString" value="0"/>
-                <Option name="trim_distance_end" type="QString" value="0"/>
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-                <Option name="trim_distance_start" type="QString" value="0"/>
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-                <Option name="use_custom_dash" type="QString" value="0"/>
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option value="0" name="align_dash_pattern" type="QString"/>
+                <Option value="square" name="capstyle" type="QString"/>
+                <Option value="5;2" name="customdash" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+                <Option value="MM" name="customdash_unit" type="QString"/>
+                <Option value="0" name="dash_pattern_offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+                <Option value="0" name="draw_inside_polygon" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="141,90,153,255" name="line_color" type="QString"/>
+                <Option value="solid" name="line_style" type="QString"/>
+                <Option value="0.6" name="line_width" type="QString"/>
+                <Option value="MM" name="line_width_unit" type="QString"/>
+                <Option value="0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="0" name="ring_filter" type="QString"/>
+                <Option value="0" name="trim_distance_end" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+                <Option value="0" name="trim_distance_start" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+                <Option value="0" name="use_custom_dash" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+          <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="fill" frame_rate="10" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" enabled="1" id="{6cc0d831-2952-4167-86d1-0595e01c9c21}" locked="0" pass="0">
+            <layer id="{6cc0d831-2952-4167-86d1-0595e01c9c21}" locked="0" class="SimpleFill" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="color" type="QString" value="141,90,153,255,rgb:0.55294120311737061,0.35294118523597717,0.60000002384185791,1"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="101,64,109,255,rgb:0.39494925737380981,0.25209429860115051,0.42856487631797791,1"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0.2"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="style" type="QString" value="solid"/>
+                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+                <Option value="141,90,153,255" name="color" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="101,64,109,255" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0.2" name="outline_width" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="solid" name="style" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+          <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="marker" frame_rate="10" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleMarker" enabled="1" id="{e1322df3-32bf-4d1a-990c-2a07f4e02d90}" locked="0" pass="0">
+            <layer id="{e1322df3-32bf-4d1a-990c-2a07f4e02d90}" locked="0" class="SimpleMarker" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0"/>
-                <Option name="cap_style" type="QString" value="square"/>
-                <Option name="color" type="QString" value="141,90,153,255,rgb:0.55294120311737061,0.35294118523597717,0.60000002384185791,1"/>
-                <Option name="horizontal_anchor_point" type="QString" value="1"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="name" type="QString" value="diamond"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="101,64,109,255,rgb:0.39494925737380981,0.25209429860115051,0.42856487631797791,1"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0.2"/>
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="scale_method" type="QString" value="diameter"/>
-                <Option name="size" type="QString" value="3"/>
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="size_unit" type="QString" value="MM"/>
-                <Option name="vertical_anchor_point" type="QString" value="1"/>
+                <Option value="0" name="angle" type="QString"/>
+                <Option value="square" name="cap_style" type="QString"/>
+                <Option value="141,90,153,255" name="color" type="QString"/>
+                <Option value="1" name="horizontal_anchor_point" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="diamond" name="name" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="101,64,109,255" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0.2" name="outline_width" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="diameter" name="scale_method" type="QString"/>
+                <Option value="3" name="size" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+                <Option value="MM" name="size_unit" type="QString"/>
+                <Option value="1" name="vertical_anchor_point" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileMarkerSymbol>
       </elevation>
-      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
         <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+          <symbol alpha="1" name="0" clip_to_extent="1" force_rhr="0" type="fill" frame_rate="10" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" enabled="1" id="{472c1a51-021b-40af-b421-03f5e563283e}" locked="0" pass="0">
+            <layer id="{472c1a51-021b-40af-b421-03f5e563283e}" locked="0" class="SimpleFill" enabled="1" pass="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="color" type="QString" value="224,220,202,154,rgb:0.87843137979507446,0.86274510622024536,0.7921568751335144,0.60392159223556519"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="119,116,104,154,rgb:0.46666666865348816,0.45490196347236633,0.40784314274787903,0.60392159223556519"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0.26"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="style" type="QString" value="solid"/>
+                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+                <Option value="224,220,202,154" name="color" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="119,116,104,154" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0.26" name="outline_width" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="solid" name="style" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -259,76 +259,69 @@
         </symbols>
         <rotation/>
         <sizescale/>
-        <data-defined-properties>
-          <Option type="Map">
-            <Option name="name" type="QString" value=""/>
-            <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
-          </Option>
-        </data-defined-properties>
       </renderer-v2>
       <selection mode="Default">
         <selectionColor invalid="1"/>
       </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="dualview/previewExpressions" type="QString" value="NAME"/>
-          <Option name="embeddedWidgets/count" type="QString" value="0"/>
-          <Option name="variableNames"/>
-          <Option name="variableValues"/>
+          <Option value="NAME" name="dualview/previewExpressions" type="QString"/>
+          <Option value="0" name="embeddedWidgets/count" type="QString"/>
+          <Option name="variableNames" type="invalid"/>
+          <Option name="variableValues" type="invalid"/>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties bold="0" description="Cantarell,11,-1,5,400,0,0,0,0,0,0,0,0,0,0,1" italic="0" strikethrough="0" style="" underline="0"/>
-          <attribute color="#000000" colorOpacity="1" field="" label=""/>
+      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+        <DiagramCategory diagramOrientation="Up" showAxis="0" spacing="0" sizeType="MM" opacity="1" backgroundAlpha="255" penAlpha="255" width="15" direction="1" penWidth="0" spacingUnit="MM" backgroundColor="#ffffff" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" height="15" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" spacingUnitScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" maxScaleDenominator="1e+08" rotationOffset="270" minScaleDenominator="0" enabled="0" minimumSize="0" scaleBasedVisibility="0" lineSizeType="MM">
+          <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" italic="0" underline="0" strikethrough="0" style=""/>
+          <attribute field="" colorOpacity="1" color="#000000" label=""/>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="line" frame_rate="10" is_animated="0">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer class="SimpleLine" enabled="1" id="{aa589d62-2b63-4ce0-937c-49b3497bce05}" locked="0" pass="0">
+              <layer id="{aa589d62-2b63-4ce0-937c-49b3497bce05}" locked="0" class="SimpleLine" enabled="1" pass="0">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" type="QString" value="0"/>
-                  <Option name="capstyle" type="QString" value="square"/>
-                  <Option name="customdash" type="QString" value="5;2"/>
-                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="customdash_unit" type="QString" value="MM"/>
-                  <Option name="dash_pattern_offset" type="QString" value="0"/>
-                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-                  <Option name="draw_inside_polygon" type="QString" value="0"/>
-                  <Option name="joinstyle" type="QString" value="bevel"/>
-                  <Option name="line_color" type="QString" value="35,35,35,255,rgb:0.13725490868091583,0.13725490868091583,0.13725490868091583,1"/>
-                  <Option name="line_style" type="QString" value="solid"/>
-                  <Option name="line_width" type="QString" value="0.26"/>
-                  <Option name="line_width_unit" type="QString" value="MM"/>
-                  <Option name="offset" type="QString" value="0"/>
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="offset_unit" type="QString" value="MM"/>
-                  <Option name="ring_filter" type="QString" value="0"/>
-                  <Option name="trim_distance_end" type="QString" value="0"/>
-                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-                  <Option name="trim_distance_start" type="QString" value="0"/>
-                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-                  <Option name="use_custom_dash" type="QString" value="0"/>
-                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                  <Option value="0" name="align_dash_pattern" type="QString"/>
+                  <Option value="square" name="capstyle" type="QString"/>
+                  <Option value="5;2" name="customdash" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="customdash_unit" type="QString"/>
+                  <Option value="0" name="dash_pattern_offset" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+                  <Option value="0" name="draw_inside_polygon" type="QString"/>
+                  <Option value="bevel" name="joinstyle" type="QString"/>
+                  <Option value="35,35,35,255" name="line_color" type="QString"/>
+                  <Option value="solid" name="line_style" type="QString"/>
+                  <Option value="0.26" name="line_width" type="QString"/>
+                  <Option value="MM" name="line_width_unit" type="QString"/>
+                  <Option value="0" name="offset" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="offset_unit" type="QString"/>
+                  <Option value="0" name="ring_filter" type="QString"/>
+                  <Option value="0" name="trim_distance_end" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+                  <Option value="0" name="trim_distance_start" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+                  <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+                  <Option value="0" name="use_custom_dash" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
                 </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value=""/>
+                    <Option value="" name="name" type="QString"/>
                     <Option name="properties"/>
-                    <Option name="type" type="QString" value="collection"/>
+                    <Option value="collection" name="type" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -336,65 +329,65 @@
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
+      <DiagramLayerSettings placement="0" zIndex="0" obstacle="0" priority="0" dist="0" linePlacementFlags="18" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
       <legend showLabelLegend="0" type="default-vector"/>
       <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="NoFlag" name="fid">
+        <field name="fid" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="iso_a2">
+        <field name="iso_a2" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="NAME">
+        <field name="NAME" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="FIPS_10_">
+        <field name="FIPS_10_" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="ISO_A3">
+        <field name="ISO_A3" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="WB_A2">
+        <field name="WB_A2" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="WB_A3">
+        <field name="WB_A3" configurationFlags="NoFlag">
           <editWidget type="TextEdit">
             <config>
               <Option/>
@@ -403,13 +396,13 @@
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="fid" index="0" name=""/>
-        <alias field="iso_a2" index="1" name=""/>
-        <alias field="NAME" index="2" name=""/>
-        <alias field="FIPS_10_" index="3" name=""/>
-        <alias field="ISO_A3" index="4" name=""/>
-        <alias field="WB_A2" index="5" name=""/>
-        <alias field="WB_A3" index="6" name=""/>
+        <alias name="" field="fid" index="0"/>
+        <alias name="" field="iso_a2" index="1"/>
+        <alias name="" field="NAME" index="2"/>
+        <alias name="" field="FIPS_10_" index="3"/>
+        <alias name="" field="ISO_A3" index="4"/>
+        <alias name="" field="WB_A2" index="5"/>
+        <alias name="" field="WB_A3" index="6"/>
       </aliases>
       <splitPolicies>
         <policy field="fid" policy="Duplicate"/>
@@ -420,56 +413,47 @@
         <policy field="WB_A2" policy="Duplicate"/>
         <policy field="WB_A3" policy="Duplicate"/>
       </splitPolicies>
-      <duplicatePolicies>
-        <policy field="fid" policy="Duplicate"/>
-        <policy field="iso_a2" policy="Duplicate"/>
-        <policy field="NAME" policy="Duplicate"/>
-        <policy field="FIPS_10_" policy="Duplicate"/>
-        <policy field="ISO_A3" policy="Duplicate"/>
-        <policy field="WB_A2" policy="Duplicate"/>
-        <policy field="WB_A3" policy="Duplicate"/>
-      </duplicatePolicies>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="fid"/>
-        <default applyOnUpdate="0" expression="" field="iso_a2"/>
-        <default applyOnUpdate="0" expression="" field="NAME"/>
-        <default applyOnUpdate="0" expression="" field="FIPS_10_"/>
-        <default applyOnUpdate="0" expression="" field="ISO_A3"/>
-        <default applyOnUpdate="0" expression="" field="WB_A2"/>
-        <default applyOnUpdate="0" expression="" field="WB_A3"/>
+        <default field="fid" expression="" applyOnUpdate="0"/>
+        <default field="iso_a2" expression="" applyOnUpdate="0"/>
+        <default field="NAME" expression="" applyOnUpdate="0"/>
+        <default field="FIPS_10_" expression="" applyOnUpdate="0"/>
+        <default field="ISO_A3" expression="" applyOnUpdate="0"/>
+        <default field="WB_A2" expression="" applyOnUpdate="0"/>
+        <default field="WB_A3" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"/>
-        <constraint constraints="0" exp_strength="0" field="iso_a2" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="NAME" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="FIPS_10_" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="ISO_A3" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="WB_A2" notnull_strength="0" unique_strength="0"/>
-        <constraint constraints="0" exp_strength="0" field="WB_A3" notnull_strength="0" unique_strength="0"/>
+        <constraint unique_strength="1" field="fid" notnull_strength="1" exp_strength="0" constraints="3"/>
+        <constraint unique_strength="0" field="iso_a2" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="NAME" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="FIPS_10_" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="ISO_A3" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="WB_A2" notnull_strength="0" exp_strength="0" constraints="0"/>
+        <constraint unique_strength="0" field="WB_A3" notnull_strength="0" exp_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="fid"/>
-        <constraint desc="" exp="" field="iso_a2"/>
-        <constraint desc="" exp="" field="NAME"/>
-        <constraint desc="" exp="" field="FIPS_10_"/>
-        <constraint desc="" exp="" field="ISO_A3"/>
-        <constraint desc="" exp="" field="WB_A2"/>
-        <constraint desc="" exp="" field="WB_A3"/>
+        <constraint field="fid" exp="" desc=""/>
+        <constraint field="iso_a2" exp="" desc=""/>
+        <constraint field="NAME" exp="" desc=""/>
+        <constraint field="FIPS_10_" exp="" desc=""/>
+        <constraint field="ISO_A3" exp="" desc=""/>
+        <constraint field="WB_A2" exp="" desc=""/>
+        <constraint field="WB_A3" exp="" desc=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
       </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
         <columns>
-          <column hidden="0" name="NAME" type="field" width="-1"/>
-          <column hidden="0" name="FIPS_10_" type="field" width="-1"/>
-          <column hidden="0" name="ISO_A3" type="field" width="-1"/>
-          <column hidden="0" name="WB_A2" type="field" width="-1"/>
-          <column hidden="0" name="WB_A3" type="field" width="-1"/>
-          <column hidden="1" type="actions" width="-1"/>
-          <column hidden="0" name="fid" type="field" width="-1"/>
-          <column hidden="0" name="iso_a2" type="field" width="-1"/>
+          <column name="NAME" hidden="0" width="-1" type="field"/>
+          <column name="FIPS_10_" hidden="0" width="-1" type="field"/>
+          <column name="ISO_A3" hidden="0" width="-1" type="field"/>
+          <column name="WB_A2" hidden="0" width="-1" type="field"/>
+          <column name="WB_A3" hidden="0" width="-1" type="field"/>
+          <column hidden="1" width="-1" type="actions"/>
+          <column name="fid" hidden="0" width="-1" type="field"/>
+          <column name="iso_a2" hidden="0" width="-1" type="field"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -501,200 +485,200 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="ABBREV"/>
-        <field editable="1" name="ABBREV_LEN"/>
-        <field editable="1" name="ADM0_A3"/>
-        <field editable="1" name="ADM0_A3_IS"/>
-        <field editable="1" name="ADM0_A3_UN"/>
-        <field editable="1" name="ADM0_A3_US"/>
-        <field editable="1" name="ADM0_A3_WB"/>
-        <field editable="1" name="ADM0_DIF"/>
-        <field editable="1" name="ADMIN"/>
-        <field editable="1" name="BRK_A3"/>
-        <field editable="1" name="BRK_DIFF"/>
-        <field editable="1" name="BRK_GROUP"/>
-        <field editable="1" name="BRK_NAME"/>
-        <field editable="1" name="CONTINENT"/>
-        <field editable="1" name="ECONOMY"/>
-        <field editable="1" name="FIPS_10_"/>
-        <field editable="1" name="FORMAL_EN"/>
-        <field editable="1" name="FORMAL_FR"/>
-        <field editable="1" name="GDP_MD_EST"/>
-        <field editable="1" name="GDP_YEAR"/>
-        <field editable="1" name="GEOUNIT"/>
-        <field editable="1" name="GEOU_DIF"/>
-        <field editable="1" name="GU_A3"/>
-        <field editable="1" name="HOMEPART"/>
-        <field editable="1" name="INCOME_GRP"/>
-        <field editable="1" name="ISO_A2"/>
-        <field editable="1" name="ISO_A3"/>
-        <field editable="1" name="ISO_A3_EH"/>
-        <field editable="1" name="ISO_N3"/>
-        <field editable="1" name="LABELRANK"/>
-        <field editable="1" name="LASTCENSUS"/>
-        <field editable="1" name="LEVEL"/>
-        <field editable="1" name="LONG_LEN"/>
-        <field editable="1" name="MAPCOLOR13"/>
-        <field editable="1" name="MAPCOLOR7"/>
-        <field editable="1" name="MAPCOLOR8"/>
-        <field editable="1" name="MAPCOLOR9"/>
-        <field editable="1" name="MAX_LABEL"/>
-        <field editable="1" name="MIN_LABEL"/>
-        <field editable="1" name="MIN_ZOOM"/>
-        <field editable="1" name="NAME"/>
-        <field editable="1" name="NAME_ALT"/>
-        <field editable="1" name="NAME_AR"/>
-        <field editable="1" name="NAME_BN"/>
-        <field editable="1" name="NAME_CIAWF"/>
-        <field editable="1" name="NAME_DE"/>
-        <field editable="1" name="NAME_EL"/>
-        <field editable="1" name="NAME_EN"/>
-        <field editable="1" name="NAME_ES"/>
-        <field editable="1" name="NAME_FR"/>
-        <field editable="1" name="NAME_HI"/>
-        <field editable="1" name="NAME_HU"/>
-        <field editable="1" name="NAME_ID"/>
-        <field editable="1" name="NAME_IT"/>
-        <field editable="1" name="NAME_JA"/>
-        <field editable="1" name="NAME_KO"/>
-        <field editable="1" name="NAME_LEN"/>
-        <field editable="1" name="NAME_LONG"/>
-        <field editable="1" name="NAME_NL"/>
-        <field editable="1" name="NAME_PL"/>
-        <field editable="1" name="NAME_PT"/>
-        <field editable="1" name="NAME_RU"/>
-        <field editable="1" name="NAME_SORT"/>
-        <field editable="1" name="NAME_SV"/>
-        <field editable="1" name="NAME_TR"/>
-        <field editable="1" name="NAME_VI"/>
-        <field editable="1" name="NAME_ZH"/>
-        <field editable="1" name="NE_ID"/>
-        <field editable="1" name="NOTE_ADM0"/>
-        <field editable="1" name="NOTE_BRK"/>
-        <field editable="1" name="POP_EST"/>
-        <field editable="1" name="POP_RANK"/>
-        <field editable="1" name="POP_YEAR"/>
-        <field editable="1" name="POSTAL"/>
-        <field editable="1" name="REGION_UN"/>
-        <field editable="1" name="REGION_WB"/>
-        <field editable="1" name="SOVEREIGNT"/>
-        <field editable="1" name="SOV_A3"/>
-        <field editable="1" name="SUBREGION"/>
-        <field editable="1" name="SUBUNIT"/>
-        <field editable="1" name="SU_A3"/>
-        <field editable="1" name="SU_DIF"/>
-        <field editable="1" name="TINY"/>
-        <field editable="1" name="TYPE"/>
-        <field editable="1" name="UN_A3"/>
-        <field editable="1" name="WB_A2"/>
-        <field editable="1" name="WB_A3"/>
-        <field editable="1" name="WIKIDATAID"/>
-        <field editable="1" name="WIKIPEDIA"/>
-        <field editable="1" name="WOE_ID"/>
-        <field editable="1" name="WOE_ID_EH"/>
-        <field editable="1" name="WOE_NOTE"/>
-        <field editable="1" name="featurecla"/>
-        <field editable="1" name="fid"/>
-        <field editable="1" name="iso_a2"/>
-        <field editable="1" name="scalerank"/>
+        <field name="ABBREV" editable="1"/>
+        <field name="ABBREV_LEN" editable="1"/>
+        <field name="ADM0_A3" editable="1"/>
+        <field name="ADM0_A3_IS" editable="1"/>
+        <field name="ADM0_A3_UN" editable="1"/>
+        <field name="ADM0_A3_US" editable="1"/>
+        <field name="ADM0_A3_WB" editable="1"/>
+        <field name="ADM0_DIF" editable="1"/>
+        <field name="ADMIN" editable="1"/>
+        <field name="BRK_A3" editable="1"/>
+        <field name="BRK_DIFF" editable="1"/>
+        <field name="BRK_GROUP" editable="1"/>
+        <field name="BRK_NAME" editable="1"/>
+        <field name="CONTINENT" editable="1"/>
+        <field name="ECONOMY" editable="1"/>
+        <field name="FIPS_10_" editable="1"/>
+        <field name="FORMAL_EN" editable="1"/>
+        <field name="FORMAL_FR" editable="1"/>
+        <field name="GDP_MD_EST" editable="1"/>
+        <field name="GDP_YEAR" editable="1"/>
+        <field name="GEOUNIT" editable="1"/>
+        <field name="GEOU_DIF" editable="1"/>
+        <field name="GU_A3" editable="1"/>
+        <field name="HOMEPART" editable="1"/>
+        <field name="INCOME_GRP" editable="1"/>
+        <field name="ISO_A2" editable="1"/>
+        <field name="ISO_A3" editable="1"/>
+        <field name="ISO_A3_EH" editable="1"/>
+        <field name="ISO_N3" editable="1"/>
+        <field name="LABELRANK" editable="1"/>
+        <field name="LASTCENSUS" editable="1"/>
+        <field name="LEVEL" editable="1"/>
+        <field name="LONG_LEN" editable="1"/>
+        <field name="MAPCOLOR13" editable="1"/>
+        <field name="MAPCOLOR7" editable="1"/>
+        <field name="MAPCOLOR8" editable="1"/>
+        <field name="MAPCOLOR9" editable="1"/>
+        <field name="MAX_LABEL" editable="1"/>
+        <field name="MIN_LABEL" editable="1"/>
+        <field name="MIN_ZOOM" editable="1"/>
+        <field name="NAME" editable="1"/>
+        <field name="NAME_ALT" editable="1"/>
+        <field name="NAME_AR" editable="1"/>
+        <field name="NAME_BN" editable="1"/>
+        <field name="NAME_CIAWF" editable="1"/>
+        <field name="NAME_DE" editable="1"/>
+        <field name="NAME_EL" editable="1"/>
+        <field name="NAME_EN" editable="1"/>
+        <field name="NAME_ES" editable="1"/>
+        <field name="NAME_FR" editable="1"/>
+        <field name="NAME_HI" editable="1"/>
+        <field name="NAME_HU" editable="1"/>
+        <field name="NAME_ID" editable="1"/>
+        <field name="NAME_IT" editable="1"/>
+        <field name="NAME_JA" editable="1"/>
+        <field name="NAME_KO" editable="1"/>
+        <field name="NAME_LEN" editable="1"/>
+        <field name="NAME_LONG" editable="1"/>
+        <field name="NAME_NL" editable="1"/>
+        <field name="NAME_PL" editable="1"/>
+        <field name="NAME_PT" editable="1"/>
+        <field name="NAME_RU" editable="1"/>
+        <field name="NAME_SORT" editable="1"/>
+        <field name="NAME_SV" editable="1"/>
+        <field name="NAME_TR" editable="1"/>
+        <field name="NAME_VI" editable="1"/>
+        <field name="NAME_ZH" editable="1"/>
+        <field name="NE_ID" editable="1"/>
+        <field name="NOTE_ADM0" editable="1"/>
+        <field name="NOTE_BRK" editable="1"/>
+        <field name="POP_EST" editable="1"/>
+        <field name="POP_RANK" editable="1"/>
+        <field name="POP_YEAR" editable="1"/>
+        <field name="POSTAL" editable="1"/>
+        <field name="REGION_UN" editable="1"/>
+        <field name="REGION_WB" editable="1"/>
+        <field name="SOVEREIGNT" editable="1"/>
+        <field name="SOV_A3" editable="1"/>
+        <field name="SUBREGION" editable="1"/>
+        <field name="SUBUNIT" editable="1"/>
+        <field name="SU_A3" editable="1"/>
+        <field name="SU_DIF" editable="1"/>
+        <field name="TINY" editable="1"/>
+        <field name="TYPE" editable="1"/>
+        <field name="UN_A3" editable="1"/>
+        <field name="WB_A2" editable="1"/>
+        <field name="WB_A3" editable="1"/>
+        <field name="WIKIDATAID" editable="1"/>
+        <field name="WIKIPEDIA" editable="1"/>
+        <field name="WOE_ID" editable="1"/>
+        <field name="WOE_ID_EH" editable="1"/>
+        <field name="WOE_NOTE" editable="1"/>
+        <field name="featurecla" editable="1"/>
+        <field name="fid" editable="1"/>
+        <field name="iso_a2" editable="1"/>
+        <field name="scalerank" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="ABBREV"/>
-        <field labelOnTop="0" name="ABBREV_LEN"/>
-        <field labelOnTop="0" name="ADM0_A3"/>
-        <field labelOnTop="0" name="ADM0_A3_IS"/>
-        <field labelOnTop="0" name="ADM0_A3_UN"/>
-        <field labelOnTop="0" name="ADM0_A3_US"/>
-        <field labelOnTop="0" name="ADM0_A3_WB"/>
-        <field labelOnTop="0" name="ADM0_DIF"/>
-        <field labelOnTop="0" name="ADMIN"/>
-        <field labelOnTop="0" name="BRK_A3"/>
-        <field labelOnTop="0" name="BRK_DIFF"/>
-        <field labelOnTop="0" name="BRK_GROUP"/>
-        <field labelOnTop="0" name="BRK_NAME"/>
-        <field labelOnTop="0" name="CONTINENT"/>
-        <field labelOnTop="0" name="ECONOMY"/>
-        <field labelOnTop="0" name="FIPS_10_"/>
-        <field labelOnTop="0" name="FORMAL_EN"/>
-        <field labelOnTop="0" name="FORMAL_FR"/>
-        <field labelOnTop="0" name="GDP_MD_EST"/>
-        <field labelOnTop="0" name="GDP_YEAR"/>
-        <field labelOnTop="0" name="GEOUNIT"/>
-        <field labelOnTop="0" name="GEOU_DIF"/>
-        <field labelOnTop="0" name="GU_A3"/>
-        <field labelOnTop="0" name="HOMEPART"/>
-        <field labelOnTop="0" name="INCOME_GRP"/>
-        <field labelOnTop="0" name="ISO_A2"/>
-        <field labelOnTop="0" name="ISO_A3"/>
-        <field labelOnTop="0" name="ISO_A3_EH"/>
-        <field labelOnTop="0" name="ISO_N3"/>
-        <field labelOnTop="0" name="LABELRANK"/>
-        <field labelOnTop="0" name="LASTCENSUS"/>
-        <field labelOnTop="0" name="LEVEL"/>
-        <field labelOnTop="0" name="LONG_LEN"/>
-        <field labelOnTop="0" name="MAPCOLOR13"/>
-        <field labelOnTop="0" name="MAPCOLOR7"/>
-        <field labelOnTop="0" name="MAPCOLOR8"/>
-        <field labelOnTop="0" name="MAPCOLOR9"/>
-        <field labelOnTop="0" name="MAX_LABEL"/>
-        <field labelOnTop="0" name="MIN_LABEL"/>
-        <field labelOnTop="0" name="MIN_ZOOM"/>
-        <field labelOnTop="0" name="NAME"/>
-        <field labelOnTop="0" name="NAME_ALT"/>
-        <field labelOnTop="0" name="NAME_AR"/>
-        <field labelOnTop="0" name="NAME_BN"/>
-        <field labelOnTop="0" name="NAME_CIAWF"/>
-        <field labelOnTop="0" name="NAME_DE"/>
-        <field labelOnTop="0" name="NAME_EL"/>
-        <field labelOnTop="0" name="NAME_EN"/>
-        <field labelOnTop="0" name="NAME_ES"/>
-        <field labelOnTop="0" name="NAME_FR"/>
-        <field labelOnTop="0" name="NAME_HI"/>
-        <field labelOnTop="0" name="NAME_HU"/>
-        <field labelOnTop="0" name="NAME_ID"/>
-        <field labelOnTop="0" name="NAME_IT"/>
-        <field labelOnTop="0" name="NAME_JA"/>
-        <field labelOnTop="0" name="NAME_KO"/>
-        <field labelOnTop="0" name="NAME_LEN"/>
-        <field labelOnTop="0" name="NAME_LONG"/>
-        <field labelOnTop="0" name="NAME_NL"/>
-        <field labelOnTop="0" name="NAME_PL"/>
-        <field labelOnTop="0" name="NAME_PT"/>
-        <field labelOnTop="0" name="NAME_RU"/>
-        <field labelOnTop="0" name="NAME_SORT"/>
-        <field labelOnTop="0" name="NAME_SV"/>
-        <field labelOnTop="0" name="NAME_TR"/>
-        <field labelOnTop="0" name="NAME_VI"/>
-        <field labelOnTop="0" name="NAME_ZH"/>
-        <field labelOnTop="0" name="NE_ID"/>
-        <field labelOnTop="0" name="NOTE_ADM0"/>
-        <field labelOnTop="0" name="NOTE_BRK"/>
-        <field labelOnTop="0" name="POP_EST"/>
-        <field labelOnTop="0" name="POP_RANK"/>
-        <field labelOnTop="0" name="POP_YEAR"/>
-        <field labelOnTop="0" name="POSTAL"/>
-        <field labelOnTop="0" name="REGION_UN"/>
-        <field labelOnTop="0" name="REGION_WB"/>
-        <field labelOnTop="0" name="SOVEREIGNT"/>
-        <field labelOnTop="0" name="SOV_A3"/>
-        <field labelOnTop="0" name="SUBREGION"/>
-        <field labelOnTop="0" name="SUBUNIT"/>
-        <field labelOnTop="0" name="SU_A3"/>
-        <field labelOnTop="0" name="SU_DIF"/>
-        <field labelOnTop="0" name="TINY"/>
-        <field labelOnTop="0" name="TYPE"/>
-        <field labelOnTop="0" name="UN_A3"/>
-        <field labelOnTop="0" name="WB_A2"/>
-        <field labelOnTop="0" name="WB_A3"/>
-        <field labelOnTop="0" name="WIKIDATAID"/>
-        <field labelOnTop="0" name="WIKIPEDIA"/>
-        <field labelOnTop="0" name="WOE_ID"/>
-        <field labelOnTop="0" name="WOE_ID_EH"/>
-        <field labelOnTop="0" name="WOE_NOTE"/>
-        <field labelOnTop="0" name="featurecla"/>
-        <field labelOnTop="0" name="fid"/>
-        <field labelOnTop="0" name="iso_a2"/>
-        <field labelOnTop="0" name="scalerank"/>
+        <field name="ABBREV" labelOnTop="0"/>
+        <field name="ABBREV_LEN" labelOnTop="0"/>
+        <field name="ADM0_A3" labelOnTop="0"/>
+        <field name="ADM0_A3_IS" labelOnTop="0"/>
+        <field name="ADM0_A3_UN" labelOnTop="0"/>
+        <field name="ADM0_A3_US" labelOnTop="0"/>
+        <field name="ADM0_A3_WB" labelOnTop="0"/>
+        <field name="ADM0_DIF" labelOnTop="0"/>
+        <field name="ADMIN" labelOnTop="0"/>
+        <field name="BRK_A3" labelOnTop="0"/>
+        <field name="BRK_DIFF" labelOnTop="0"/>
+        <field name="BRK_GROUP" labelOnTop="0"/>
+        <field name="BRK_NAME" labelOnTop="0"/>
+        <field name="CONTINENT" labelOnTop="0"/>
+        <field name="ECONOMY" labelOnTop="0"/>
+        <field name="FIPS_10_" labelOnTop="0"/>
+        <field name="FORMAL_EN" labelOnTop="0"/>
+        <field name="FORMAL_FR" labelOnTop="0"/>
+        <field name="GDP_MD_EST" labelOnTop="0"/>
+        <field name="GDP_YEAR" labelOnTop="0"/>
+        <field name="GEOUNIT" labelOnTop="0"/>
+        <field name="GEOU_DIF" labelOnTop="0"/>
+        <field name="GU_A3" labelOnTop="0"/>
+        <field name="HOMEPART" labelOnTop="0"/>
+        <field name="INCOME_GRP" labelOnTop="0"/>
+        <field name="ISO_A2" labelOnTop="0"/>
+        <field name="ISO_A3" labelOnTop="0"/>
+        <field name="ISO_A3_EH" labelOnTop="0"/>
+        <field name="ISO_N3" labelOnTop="0"/>
+        <field name="LABELRANK" labelOnTop="0"/>
+        <field name="LASTCENSUS" labelOnTop="0"/>
+        <field name="LEVEL" labelOnTop="0"/>
+        <field name="LONG_LEN" labelOnTop="0"/>
+        <field name="MAPCOLOR13" labelOnTop="0"/>
+        <field name="MAPCOLOR7" labelOnTop="0"/>
+        <field name="MAPCOLOR8" labelOnTop="0"/>
+        <field name="MAPCOLOR9" labelOnTop="0"/>
+        <field name="MAX_LABEL" labelOnTop="0"/>
+        <field name="MIN_LABEL" labelOnTop="0"/>
+        <field name="MIN_ZOOM" labelOnTop="0"/>
+        <field name="NAME" labelOnTop="0"/>
+        <field name="NAME_ALT" labelOnTop="0"/>
+        <field name="NAME_AR" labelOnTop="0"/>
+        <field name="NAME_BN" labelOnTop="0"/>
+        <field name="NAME_CIAWF" labelOnTop="0"/>
+        <field name="NAME_DE" labelOnTop="0"/>
+        <field name="NAME_EL" labelOnTop="0"/>
+        <field name="NAME_EN" labelOnTop="0"/>
+        <field name="NAME_ES" labelOnTop="0"/>
+        <field name="NAME_FR" labelOnTop="0"/>
+        <field name="NAME_HI" labelOnTop="0"/>
+        <field name="NAME_HU" labelOnTop="0"/>
+        <field name="NAME_ID" labelOnTop="0"/>
+        <field name="NAME_IT" labelOnTop="0"/>
+        <field name="NAME_JA" labelOnTop="0"/>
+        <field name="NAME_KO" labelOnTop="0"/>
+        <field name="NAME_LEN" labelOnTop="0"/>
+        <field name="NAME_LONG" labelOnTop="0"/>
+        <field name="NAME_NL" labelOnTop="0"/>
+        <field name="NAME_PL" labelOnTop="0"/>
+        <field name="NAME_PT" labelOnTop="0"/>
+        <field name="NAME_RU" labelOnTop="0"/>
+        <field name="NAME_SORT" labelOnTop="0"/>
+        <field name="NAME_SV" labelOnTop="0"/>
+        <field name="NAME_TR" labelOnTop="0"/>
+        <field name="NAME_VI" labelOnTop="0"/>
+        <field name="NAME_ZH" labelOnTop="0"/>
+        <field name="NE_ID" labelOnTop="0"/>
+        <field name="NOTE_ADM0" labelOnTop="0"/>
+        <field name="NOTE_BRK" labelOnTop="0"/>
+        <field name="POP_EST" labelOnTop="0"/>
+        <field name="POP_RANK" labelOnTop="0"/>
+        <field name="POP_YEAR" labelOnTop="0"/>
+        <field name="POSTAL" labelOnTop="0"/>
+        <field name="REGION_UN" labelOnTop="0"/>
+        <field name="REGION_WB" labelOnTop="0"/>
+        <field name="SOVEREIGNT" labelOnTop="0"/>
+        <field name="SOV_A3" labelOnTop="0"/>
+        <field name="SUBREGION" labelOnTop="0"/>
+        <field name="SUBUNIT" labelOnTop="0"/>
+        <field name="SU_A3" labelOnTop="0"/>
+        <field name="SU_DIF" labelOnTop="0"/>
+        <field name="TINY" labelOnTop="0"/>
+        <field name="TYPE" labelOnTop="0"/>
+        <field name="UN_A3" labelOnTop="0"/>
+        <field name="WB_A2" labelOnTop="0"/>
+        <field name="WB_A3" labelOnTop="0"/>
+        <field name="WIKIDATAID" labelOnTop="0"/>
+        <field name="WIKIPEDIA" labelOnTop="0"/>
+        <field name="WOE_ID" labelOnTop="0"/>
+        <field name="WOE_ID_EH" labelOnTop="0"/>
+        <field name="WOE_NOTE" labelOnTop="0"/>
+        <field name="featurecla" labelOnTop="0"/>
+        <field name="fid" labelOnTop="0"/>
+        <field name="iso_a2" labelOnTop="0"/>
+        <field name="scalerank" labelOnTop="0"/>
       </labelOnTop>
       <reuseLastValue/>
       <dataDefinedFieldProperties/>

--- a/world.qml
+++ b/world.qml
@@ -1,178 +1,178 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="0" readOnly="0" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" version="3.39.0-Master">
+<qgis styleCategories="AllStyleCategories" symbologyReferenceScale="-1" simplifyAlgorithm="0" maxScale="0" readOnly="0" hasScaleBasedVisibilityFlag="0" minScale="0" simplifyDrawingTol="1" simplifyMaxScale="1" labelsEnabled="0" simplifyLocal="1" version="3.34.10-Prizren" simplifyDrawingHints="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+  <temporal endExpression="" durationUnit="min" limitMode="0" durationField="" enabled="0" startExpression="" fixedDuration="0" startField="" endField="" accumulate="0" mode="0">
     <fixedRange>
       <start></start>
       <end></end>
     </fixedRange>
   </temporal>
-  <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+  <elevation extrusion="0" showMarkerSymbolInSurfacePlots="0" zscale="1" binding="Centroid" zoffset="0" type="IndividualFeatures" respectLayerSymbol="1" clamping="Terrain" extrusionEnabled="0" symbology="Line">
     <data-defined-properties>
       <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </data-defined-properties>
     <profileLineSymbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+      <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="line" frame_rate="10" is_animated="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleLine" enabled="1" id="{a30db034-3641-4edb-8ca7-fc6f8595ac83}" locked="0" pass="0">
+        <layer id="{a30db034-3641-4edb-8ca7-fc6f8595ac83}" locked="0" class="SimpleLine" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0"/>
-            <Option name="capstyle" type="QString" value="square"/>
-            <Option name="customdash" type="QString" value="5;2"/>
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="customdash_unit" type="QString" value="MM"/>
-            <Option name="dash_pattern_offset" type="QString" value="0"/>
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-            <Option name="draw_inside_polygon" type="QString" value="0"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="line_color" type="QString" value="141,90,153,255,rgb:0.55294120311737061,0.35294118523597717,0.60000002384185791,1"/>
-            <Option name="line_style" type="QString" value="solid"/>
-            <Option name="line_width" type="QString" value="0.6"/>
-            <Option name="line_width_unit" type="QString" value="MM"/>
-            <Option name="offset" type="QString" value="0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="ring_filter" type="QString" value="0"/>
-            <Option name="trim_distance_end" type="QString" value="0"/>
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-            <Option name="trim_distance_start" type="QString" value="0"/>
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-            <Option name="use_custom_dash" type="QString" value="0"/>
-            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option value="0" name="align_dash_pattern" type="QString"/>
+            <Option value="square" name="capstyle" type="QString"/>
+            <Option value="5;2" name="customdash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+            <Option value="MM" name="customdash_unit" type="QString"/>
+            <Option value="0" name="dash_pattern_offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+            <Option value="0" name="draw_inside_polygon" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="141,90,153,255" name="line_color" type="QString"/>
+            <Option value="solid" name="line_style" type="QString"/>
+            <Option value="0.6" name="line_width" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0" name="ring_filter" type="QString"/>
+            <Option value="0" name="trim_distance_end" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+            <Option value="0" name="trim_distance_start" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+            <Option value="0" name="use_custom_dash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileLineSymbol>
     <profileFillSymbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+      <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="fill" frame_rate="10" is_animated="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" enabled="1" id="{6cc0d831-2952-4167-86d1-0595e01c9c21}" locked="0" pass="0">
+        <layer id="{6cc0d831-2952-4167-86d1-0595e01c9c21}" locked="0" class="SimpleFill" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="color" type="QString" value="141,90,153,255,rgb:0.55294120311737061,0.35294118523597717,0.60000002384185791,1"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="101,64,109,255,rgb:0.39494925737380981,0.25209429860115051,0.42856487631797791,1"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.2"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="style" type="QString" value="solid"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="141,90,153,255" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="101,64,109,255" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.2" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileFillSymbol>
     <profileMarkerSymbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+      <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="marker" frame_rate="10" is_animated="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleMarker" enabled="1" id="{e1322df3-32bf-4d1a-990c-2a07f4e02d90}" locked="0" pass="0">
+        <layer id="{e1322df3-32bf-4d1a-990c-2a07f4e02d90}" locked="0" class="SimpleMarker" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="angle" type="QString" value="0"/>
-            <Option name="cap_style" type="QString" value="square"/>
-            <Option name="color" type="QString" value="141,90,153,255,rgb:0.55294120311737061,0.35294118523597717,0.60000002384185791,1"/>
-            <Option name="horizontal_anchor_point" type="QString" value="1"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="name" type="QString" value="diamond"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="101,64,109,255,rgb:0.39494925737380981,0.25209429860115051,0.42856487631797791,1"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.2"/>
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="scale_method" type="QString" value="diameter"/>
-            <Option name="size" type="QString" value="3"/>
-            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="size_unit" type="QString" value="MM"/>
-            <Option name="vertical_anchor_point" type="QString" value="1"/>
+            <Option value="0" name="angle" type="QString"/>
+            <Option value="square" name="cap_style" type="QString"/>
+            <Option value="141,90,153,255" name="color" type="QString"/>
+            <Option value="1" name="horizontal_anchor_point" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="diamond" name="name" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="101,64,109,255" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.2" name="outline_width" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="diameter" name="scale_method" type="QString"/>
+            <Option value="3" name="size" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+            <Option value="MM" name="size_unit" type="QString"/>
+            <Option value="1" name="vertical_anchor_point" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileMarkerSymbol>
   </elevation>
-  <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
+  <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="fill">
+      <symbol alpha="1" name="0" clip_to_extent="1" force_rhr="0" type="fill" frame_rate="10" is_animated="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" enabled="1" id="{472c1a51-021b-40af-b421-03f5e563283e}" locked="0" pass="0">
+        <layer id="{472c1a51-021b-40af-b421-03f5e563283e}" locked="0" class="SimpleFill" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="color" type="QString" value="224,220,202,154,rgb:0.87843137979507446,0.86274510622024536,0.7921568751335144,0.60392159223556519"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="119,116,104,154,rgb:0.46666666865348816,0.45490196347236633,0.40784314274787903,0.60392159223556519"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.26"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="style" type="QString" value="solid"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="224,220,202,154" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="119,116,104,154" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.26" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -180,44 +180,37 @@
     </symbols>
     <rotation/>
     <sizescale/>
-    <data-defined-properties>
-      <Option type="Map">
-        <Option name="name" type="QString" value=""/>
-        <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
-      </Option>
-    </data-defined-properties>
   </renderer-v2>
   <selection mode="Default">
     <selectionColor invalid="1"/>
     <selectionSymbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+      <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="fill" frame_rate="10" is_animated="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" enabled="1" id="{2733ffb6-f1bf-44ae-924e-148f606bdaa1}" locked="0" pass="0">
+        <layer id="{2733ffb6-f1bf-44ae-924e-148f606bdaa1}" locked="0" class="SimpleFill" enabled="1" pass="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="color" type="QString" value="0,0,255,255,rgb:0,0,1,1"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="35,35,35,255,rgb:0.13725490868091583,0.13725490868091583,0.13725490868091583,1"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.26"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="style" type="QString" value="solid"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="0,0,255,255" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="35,35,35,255" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.26" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -226,8 +219,8 @@
   </selection>
   <customproperties>
     <Option type="Map">
-      <Option name="dualview/previewExpressions" type="QString" value="NAME"/>
-      <Option name="embeddedWidgets/count" type="QString" value="0"/>
+      <Option value="NAME" name="dualview/previewExpressions" type="QString"/>
+      <Option value="0" name="embeddedWidgets/count" type="QString"/>
       <Option name="variableNames"/>
       <Option name="variableValues"/>
     </Option>
@@ -235,54 +228,54 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-      <fontProperties bold="0" description="Cantarell,11,-1,5,400,0,0,0,0,0,0,0,0,0,0,1" italic="0" strikethrough="0" style="" underline="0"/>
-      <attribute color="#000000" colorOpacity="1" field="" label=""/>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory diagramOrientation="Up" showAxis="0" spacing="0" sizeType="MM" opacity="1" backgroundAlpha="255" penAlpha="255" width="15" direction="1" penWidth="0" spacingUnit="MM" backgroundColor="#ffffff" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" height="15" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" spacingUnitScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" maxScaleDenominator="1e+08" rotationOffset="270" minScaleDenominator="0" enabled="0" minimumSize="0" scaleBasedVisibility="0" lineSizeType="MM">
+      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" italic="0" underline="0" strikethrough="0" style=""/>
+      <attribute field="" colorOpacity="1" color="#000000" label=""/>
       <axisSymbol>
-        <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+        <symbol alpha="1" name="" clip_to_extent="1" force_rhr="0" type="line" frame_rate="10" is_animated="0">
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleLine" enabled="1" id="{aa589d62-2b63-4ce0-937c-49b3497bce05}" locked="0" pass="0">
+          <layer id="{aa589d62-2b63-4ce0-937c-49b3497bce05}" locked="0" class="SimpleLine" enabled="1" pass="0">
             <Option type="Map">
-              <Option name="align_dash_pattern" type="QString" value="0"/>
-              <Option name="capstyle" type="QString" value="square"/>
-              <Option name="customdash" type="QString" value="5;2"/>
-              <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-              <Option name="customdash_unit" type="QString" value="MM"/>
-              <Option name="dash_pattern_offset" type="QString" value="0"/>
-              <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-              <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-              <Option name="draw_inside_polygon" type="QString" value="0"/>
-              <Option name="joinstyle" type="QString" value="bevel"/>
-              <Option name="line_color" type="QString" value="35,35,35,255,rgb:0.13725490868091583,0.13725490868091583,0.13725490868091583,1"/>
-              <Option name="line_style" type="QString" value="solid"/>
-              <Option name="line_width" type="QString" value="0.26"/>
-              <Option name="line_width_unit" type="QString" value="MM"/>
-              <Option name="offset" type="QString" value="0"/>
-              <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-              <Option name="offset_unit" type="QString" value="MM"/>
-              <Option name="ring_filter" type="QString" value="0"/>
-              <Option name="trim_distance_end" type="QString" value="0"/>
-              <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-              <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-              <Option name="trim_distance_start" type="QString" value="0"/>
-              <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-              <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-              <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-              <Option name="use_custom_dash" type="QString" value="0"/>
-              <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              <Option value="0" name="align_dash_pattern" type="QString"/>
+              <Option value="square" name="capstyle" type="QString"/>
+              <Option value="5;2" name="customdash" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+              <Option value="MM" name="customdash_unit" type="QString"/>
+              <Option value="0" name="dash_pattern_offset" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+              <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+              <Option value="0" name="draw_inside_polygon" type="QString"/>
+              <Option value="bevel" name="joinstyle" type="QString"/>
+              <Option value="35,35,35,255" name="line_color" type="QString"/>
+              <Option value="solid" name="line_style" type="QString"/>
+              <Option value="0.26" name="line_width" type="QString"/>
+              <Option value="MM" name="line_width_unit" type="QString"/>
+              <Option value="0" name="offset" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="0" name="ring_filter" type="QString"/>
+              <Option value="0" name="trim_distance_end" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+              <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+              <Option value="0" name="trim_distance_start" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+              <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+              <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+              <Option value="0" name="use_custom_dash" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
             </Option>
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
           </layer>
@@ -290,65 +283,71 @@
       </axisSymbol>
     </DiagramCategory>
   </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
+  <DiagramLayerSettings placement="0" zIndex="0" obstacle="0" priority="0" dist="0" linePlacementFlags="18" showAll="1">
     <properties>
       <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
     <activeChecks/>
-    <checkConfiguration/>
+    <checkConfiguration type="Map">
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option value="0" name="allowedGapsBuffer" type="double"/>
+        <Option value="false" name="allowedGapsEnabled" type="bool"/>
+        <Option value="" name="allowedGapsLayer" type="QString"/>
+      </Option>
+    </checkConfiguration>
   </geometryOptions>
   <legend showLabelLegend="0" type="default-vector"/>
   <referencedLayers/>
   <fieldConfiguration>
-    <field configurationFlags="NoFlag" name="fid">
+    <field name="fid" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="iso_a2">
+    <field name="iso_a2" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="NAME">
+    <field name="NAME" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="FIPS_10_">
+    <field name="FIPS_10_" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="ISO_A3">
+    <field name="ISO_A3" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="WB_A2">
+    <field name="WB_A2" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="WB_A3">
+    <field name="WB_A3" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
@@ -357,13 +356,13 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="fid" index="0" name=""/>
-    <alias field="iso_a2" index="1" name=""/>
-    <alias field="NAME" index="2" name=""/>
-    <alias field="FIPS_10_" index="3" name=""/>
-    <alias field="ISO_A3" index="4" name=""/>
-    <alias field="WB_A2" index="5" name=""/>
-    <alias field="WB_A3" index="6" name=""/>
+    <alias name="" field="fid" index="0"/>
+    <alias name="" field="iso_a2" index="1"/>
+    <alias name="" field="NAME" index="2"/>
+    <alias name="" field="FIPS_10_" index="3"/>
+    <alias name="" field="ISO_A3" index="4"/>
+    <alias name="" field="WB_A2" index="5"/>
+    <alias name="" field="WB_A3" index="6"/>
   </aliases>
   <splitPolicies>
     <policy field="fid" policy="Duplicate"/>
@@ -374,56 +373,47 @@
     <policy field="WB_A2" policy="Duplicate"/>
     <policy field="WB_A3" policy="Duplicate"/>
   </splitPolicies>
-  <duplicatePolicies>
-    <policy field="fid" policy="Duplicate"/>
-    <policy field="iso_a2" policy="Duplicate"/>
-    <policy field="NAME" policy="Duplicate"/>
-    <policy field="FIPS_10_" policy="Duplicate"/>
-    <policy field="ISO_A3" policy="Duplicate"/>
-    <policy field="WB_A2" policy="Duplicate"/>
-    <policy field="WB_A3" policy="Duplicate"/>
-  </duplicatePolicies>
   <defaults>
-    <default applyOnUpdate="0" expression="" field="fid"/>
-    <default applyOnUpdate="0" expression="" field="iso_a2"/>
-    <default applyOnUpdate="0" expression="" field="NAME"/>
-    <default applyOnUpdate="0" expression="" field="FIPS_10_"/>
-    <default applyOnUpdate="0" expression="" field="ISO_A3"/>
-    <default applyOnUpdate="0" expression="" field="WB_A2"/>
-    <default applyOnUpdate="0" expression="" field="WB_A3"/>
+    <default field="fid" expression="" applyOnUpdate="0"/>
+    <default field="iso_a2" expression="" applyOnUpdate="0"/>
+    <default field="NAME" expression="" applyOnUpdate="0"/>
+    <default field="FIPS_10_" expression="" applyOnUpdate="0"/>
+    <default field="ISO_A3" expression="" applyOnUpdate="0"/>
+    <default field="WB_A2" expression="" applyOnUpdate="0"/>
+    <default field="WB_A3" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint constraints="3" exp_strength="0" field="fid" notnull_strength="1" unique_strength="1"/>
-    <constraint constraints="0" exp_strength="0" field="iso_a2" notnull_strength="0" unique_strength="0"/>
-    <constraint constraints="0" exp_strength="0" field="NAME" notnull_strength="0" unique_strength="0"/>
-    <constraint constraints="0" exp_strength="0" field="FIPS_10_" notnull_strength="0" unique_strength="0"/>
-    <constraint constraints="0" exp_strength="0" field="ISO_A3" notnull_strength="0" unique_strength="0"/>
-    <constraint constraints="0" exp_strength="0" field="WB_A2" notnull_strength="0" unique_strength="0"/>
-    <constraint constraints="0" exp_strength="0" field="WB_A3" notnull_strength="0" unique_strength="0"/>
+    <constraint unique_strength="1" field="fid" notnull_strength="1" exp_strength="0" constraints="3"/>
+    <constraint unique_strength="0" field="iso_a2" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="NAME" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FIPS_10_" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ISO_A3" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="WB_A2" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="WB_A3" notnull_strength="0" exp_strength="0" constraints="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint desc="" exp="" field="fid"/>
-    <constraint desc="" exp="" field="iso_a2"/>
-    <constraint desc="" exp="" field="NAME"/>
-    <constraint desc="" exp="" field="FIPS_10_"/>
-    <constraint desc="" exp="" field="ISO_A3"/>
-    <constraint desc="" exp="" field="WB_A2"/>
-    <constraint desc="" exp="" field="WB_A3"/>
+    <constraint field="fid" exp="" desc=""/>
+    <constraint field="iso_a2" exp="" desc=""/>
+    <constraint field="NAME" exp="" desc=""/>
+    <constraint field="FIPS_10_" exp="" desc=""/>
+    <constraint field="ISO_A3" exp="" desc=""/>
+    <constraint field="WB_A2" exp="" desc=""/>
+    <constraint field="WB_A3" exp="" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
     <columns>
-      <column hidden="0" name="NAME" type="field" width="-1"/>
-      <column hidden="0" name="FIPS_10_" type="field" width="-1"/>
-      <column hidden="0" name="ISO_A3" type="field" width="-1"/>
-      <column hidden="0" name="WB_A2" type="field" width="-1"/>
-      <column hidden="0" name="WB_A3" type="field" width="-1"/>
-      <column hidden="1" type="actions" width="-1"/>
-      <column hidden="0" name="fid" type="field" width="-1"/>
-      <column hidden="0" name="iso_a2" type="field" width="-1"/>
+      <column name="NAME" hidden="0" width="-1" type="field"/>
+      <column name="FIPS_10_" hidden="0" width="-1" type="field"/>
+      <column name="ISO_A3" hidden="0" width="-1" type="field"/>
+      <column name="WB_A2" hidden="0" width="-1" type="field"/>
+      <column name="WB_A3" hidden="0" width="-1" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
+      <column name="fid" hidden="0" width="-1" type="field"/>
+      <column name="iso_a2" hidden="0" width="-1" type="field"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -455,200 +445,200 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>generatedlayout</editorlayout>
   <editable>
-    <field editable="1" name="ABBREV"/>
-    <field editable="1" name="ABBREV_LEN"/>
-    <field editable="1" name="ADM0_A3"/>
-    <field editable="1" name="ADM0_A3_IS"/>
-    <field editable="1" name="ADM0_A3_UN"/>
-    <field editable="1" name="ADM0_A3_US"/>
-    <field editable="1" name="ADM0_A3_WB"/>
-    <field editable="1" name="ADM0_DIF"/>
-    <field editable="1" name="ADMIN"/>
-    <field editable="1" name="BRK_A3"/>
-    <field editable="1" name="BRK_DIFF"/>
-    <field editable="1" name="BRK_GROUP"/>
-    <field editable="1" name="BRK_NAME"/>
-    <field editable="1" name="CONTINENT"/>
-    <field editable="1" name="ECONOMY"/>
-    <field editable="1" name="FIPS_10_"/>
-    <field editable="1" name="FORMAL_EN"/>
-    <field editable="1" name="FORMAL_FR"/>
-    <field editable="1" name="GDP_MD_EST"/>
-    <field editable="1" name="GDP_YEAR"/>
-    <field editable="1" name="GEOUNIT"/>
-    <field editable="1" name="GEOU_DIF"/>
-    <field editable="1" name="GU_A3"/>
-    <field editable="1" name="HOMEPART"/>
-    <field editable="1" name="INCOME_GRP"/>
-    <field editable="1" name="ISO_A2"/>
-    <field editable="1" name="ISO_A3"/>
-    <field editable="1" name="ISO_A3_EH"/>
-    <field editable="1" name="ISO_N3"/>
-    <field editable="1" name="LABELRANK"/>
-    <field editable="1" name="LASTCENSUS"/>
-    <field editable="1" name="LEVEL"/>
-    <field editable="1" name="LONG_LEN"/>
-    <field editable="1" name="MAPCOLOR13"/>
-    <field editable="1" name="MAPCOLOR7"/>
-    <field editable="1" name="MAPCOLOR8"/>
-    <field editable="1" name="MAPCOLOR9"/>
-    <field editable="1" name="MAX_LABEL"/>
-    <field editable="1" name="MIN_LABEL"/>
-    <field editable="1" name="MIN_ZOOM"/>
-    <field editable="1" name="NAME"/>
-    <field editable="1" name="NAME_ALT"/>
-    <field editable="1" name="NAME_AR"/>
-    <field editable="1" name="NAME_BN"/>
-    <field editable="1" name="NAME_CIAWF"/>
-    <field editable="1" name="NAME_DE"/>
-    <field editable="1" name="NAME_EL"/>
-    <field editable="1" name="NAME_EN"/>
-    <field editable="1" name="NAME_ES"/>
-    <field editable="1" name="NAME_FR"/>
-    <field editable="1" name="NAME_HI"/>
-    <field editable="1" name="NAME_HU"/>
-    <field editable="1" name="NAME_ID"/>
-    <field editable="1" name="NAME_IT"/>
-    <field editable="1" name="NAME_JA"/>
-    <field editable="1" name="NAME_KO"/>
-    <field editable="1" name="NAME_LEN"/>
-    <field editable="1" name="NAME_LONG"/>
-    <field editable="1" name="NAME_NL"/>
-    <field editable="1" name="NAME_PL"/>
-    <field editable="1" name="NAME_PT"/>
-    <field editable="1" name="NAME_RU"/>
-    <field editable="1" name="NAME_SORT"/>
-    <field editable="1" name="NAME_SV"/>
-    <field editable="1" name="NAME_TR"/>
-    <field editable="1" name="NAME_VI"/>
-    <field editable="1" name="NAME_ZH"/>
-    <field editable="1" name="NE_ID"/>
-    <field editable="1" name="NOTE_ADM0"/>
-    <field editable="1" name="NOTE_BRK"/>
-    <field editable="1" name="POP_EST"/>
-    <field editable="1" name="POP_RANK"/>
-    <field editable="1" name="POP_YEAR"/>
-    <field editable="1" name="POSTAL"/>
-    <field editable="1" name="REGION_UN"/>
-    <field editable="1" name="REGION_WB"/>
-    <field editable="1" name="SOVEREIGNT"/>
-    <field editable="1" name="SOV_A3"/>
-    <field editable="1" name="SUBREGION"/>
-    <field editable="1" name="SUBUNIT"/>
-    <field editable="1" name="SU_A3"/>
-    <field editable="1" name="SU_DIF"/>
-    <field editable="1" name="TINY"/>
-    <field editable="1" name="TYPE"/>
-    <field editable="1" name="UN_A3"/>
-    <field editable="1" name="WB_A2"/>
-    <field editable="1" name="WB_A3"/>
-    <field editable="1" name="WIKIDATAID"/>
-    <field editable="1" name="WIKIPEDIA"/>
-    <field editable="1" name="WOE_ID"/>
-    <field editable="1" name="WOE_ID_EH"/>
-    <field editable="1" name="WOE_NOTE"/>
-    <field editable="1" name="featurecla"/>
-    <field editable="1" name="fid"/>
-    <field editable="1" name="iso_a2"/>
-    <field editable="1" name="scalerank"/>
+    <field name="ABBREV" editable="1"/>
+    <field name="ABBREV_LEN" editable="1"/>
+    <field name="ADM0_A3" editable="1"/>
+    <field name="ADM0_A3_IS" editable="1"/>
+    <field name="ADM0_A3_UN" editable="1"/>
+    <field name="ADM0_A3_US" editable="1"/>
+    <field name="ADM0_A3_WB" editable="1"/>
+    <field name="ADM0_DIF" editable="1"/>
+    <field name="ADMIN" editable="1"/>
+    <field name="BRK_A3" editable="1"/>
+    <field name="BRK_DIFF" editable="1"/>
+    <field name="BRK_GROUP" editable="1"/>
+    <field name="BRK_NAME" editable="1"/>
+    <field name="CONTINENT" editable="1"/>
+    <field name="ECONOMY" editable="1"/>
+    <field name="FIPS_10_" editable="1"/>
+    <field name="FORMAL_EN" editable="1"/>
+    <field name="FORMAL_FR" editable="1"/>
+    <field name="GDP_MD_EST" editable="1"/>
+    <field name="GDP_YEAR" editable="1"/>
+    <field name="GEOUNIT" editable="1"/>
+    <field name="GEOU_DIF" editable="1"/>
+    <field name="GU_A3" editable="1"/>
+    <field name="HOMEPART" editable="1"/>
+    <field name="INCOME_GRP" editable="1"/>
+    <field name="ISO_A2" editable="1"/>
+    <field name="ISO_A3" editable="1"/>
+    <field name="ISO_A3_EH" editable="1"/>
+    <field name="ISO_N3" editable="1"/>
+    <field name="LABELRANK" editable="1"/>
+    <field name="LASTCENSUS" editable="1"/>
+    <field name="LEVEL" editable="1"/>
+    <field name="LONG_LEN" editable="1"/>
+    <field name="MAPCOLOR13" editable="1"/>
+    <field name="MAPCOLOR7" editable="1"/>
+    <field name="MAPCOLOR8" editable="1"/>
+    <field name="MAPCOLOR9" editable="1"/>
+    <field name="MAX_LABEL" editable="1"/>
+    <field name="MIN_LABEL" editable="1"/>
+    <field name="MIN_ZOOM" editable="1"/>
+    <field name="NAME" editable="1"/>
+    <field name="NAME_ALT" editable="1"/>
+    <field name="NAME_AR" editable="1"/>
+    <field name="NAME_BN" editable="1"/>
+    <field name="NAME_CIAWF" editable="1"/>
+    <field name="NAME_DE" editable="1"/>
+    <field name="NAME_EL" editable="1"/>
+    <field name="NAME_EN" editable="1"/>
+    <field name="NAME_ES" editable="1"/>
+    <field name="NAME_FR" editable="1"/>
+    <field name="NAME_HI" editable="1"/>
+    <field name="NAME_HU" editable="1"/>
+    <field name="NAME_ID" editable="1"/>
+    <field name="NAME_IT" editable="1"/>
+    <field name="NAME_JA" editable="1"/>
+    <field name="NAME_KO" editable="1"/>
+    <field name="NAME_LEN" editable="1"/>
+    <field name="NAME_LONG" editable="1"/>
+    <field name="NAME_NL" editable="1"/>
+    <field name="NAME_PL" editable="1"/>
+    <field name="NAME_PT" editable="1"/>
+    <field name="NAME_RU" editable="1"/>
+    <field name="NAME_SORT" editable="1"/>
+    <field name="NAME_SV" editable="1"/>
+    <field name="NAME_TR" editable="1"/>
+    <field name="NAME_VI" editable="1"/>
+    <field name="NAME_ZH" editable="1"/>
+    <field name="NE_ID" editable="1"/>
+    <field name="NOTE_ADM0" editable="1"/>
+    <field name="NOTE_BRK" editable="1"/>
+    <field name="POP_EST" editable="1"/>
+    <field name="POP_RANK" editable="1"/>
+    <field name="POP_YEAR" editable="1"/>
+    <field name="POSTAL" editable="1"/>
+    <field name="REGION_UN" editable="1"/>
+    <field name="REGION_WB" editable="1"/>
+    <field name="SOVEREIGNT" editable="1"/>
+    <field name="SOV_A3" editable="1"/>
+    <field name="SUBREGION" editable="1"/>
+    <field name="SUBUNIT" editable="1"/>
+    <field name="SU_A3" editable="1"/>
+    <field name="SU_DIF" editable="1"/>
+    <field name="TINY" editable="1"/>
+    <field name="TYPE" editable="1"/>
+    <field name="UN_A3" editable="1"/>
+    <field name="WB_A2" editable="1"/>
+    <field name="WB_A3" editable="1"/>
+    <field name="WIKIDATAID" editable="1"/>
+    <field name="WIKIPEDIA" editable="1"/>
+    <field name="WOE_ID" editable="1"/>
+    <field name="WOE_ID_EH" editable="1"/>
+    <field name="WOE_NOTE" editable="1"/>
+    <field name="featurecla" editable="1"/>
+    <field name="fid" editable="1"/>
+    <field name="iso_a2" editable="1"/>
+    <field name="scalerank" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="ABBREV"/>
-    <field labelOnTop="0" name="ABBREV_LEN"/>
-    <field labelOnTop="0" name="ADM0_A3"/>
-    <field labelOnTop="0" name="ADM0_A3_IS"/>
-    <field labelOnTop="0" name="ADM0_A3_UN"/>
-    <field labelOnTop="0" name="ADM0_A3_US"/>
-    <field labelOnTop="0" name="ADM0_A3_WB"/>
-    <field labelOnTop="0" name="ADM0_DIF"/>
-    <field labelOnTop="0" name="ADMIN"/>
-    <field labelOnTop="0" name="BRK_A3"/>
-    <field labelOnTop="0" name="BRK_DIFF"/>
-    <field labelOnTop="0" name="BRK_GROUP"/>
-    <field labelOnTop="0" name="BRK_NAME"/>
-    <field labelOnTop="0" name="CONTINENT"/>
-    <field labelOnTop="0" name="ECONOMY"/>
-    <field labelOnTop="0" name="FIPS_10_"/>
-    <field labelOnTop="0" name="FORMAL_EN"/>
-    <field labelOnTop="0" name="FORMAL_FR"/>
-    <field labelOnTop="0" name="GDP_MD_EST"/>
-    <field labelOnTop="0" name="GDP_YEAR"/>
-    <field labelOnTop="0" name="GEOUNIT"/>
-    <field labelOnTop="0" name="GEOU_DIF"/>
-    <field labelOnTop="0" name="GU_A3"/>
-    <field labelOnTop="0" name="HOMEPART"/>
-    <field labelOnTop="0" name="INCOME_GRP"/>
-    <field labelOnTop="0" name="ISO_A2"/>
-    <field labelOnTop="0" name="ISO_A3"/>
-    <field labelOnTop="0" name="ISO_A3_EH"/>
-    <field labelOnTop="0" name="ISO_N3"/>
-    <field labelOnTop="0" name="LABELRANK"/>
-    <field labelOnTop="0" name="LASTCENSUS"/>
-    <field labelOnTop="0" name="LEVEL"/>
-    <field labelOnTop="0" name="LONG_LEN"/>
-    <field labelOnTop="0" name="MAPCOLOR13"/>
-    <field labelOnTop="0" name="MAPCOLOR7"/>
-    <field labelOnTop="0" name="MAPCOLOR8"/>
-    <field labelOnTop="0" name="MAPCOLOR9"/>
-    <field labelOnTop="0" name="MAX_LABEL"/>
-    <field labelOnTop="0" name="MIN_LABEL"/>
-    <field labelOnTop="0" name="MIN_ZOOM"/>
-    <field labelOnTop="0" name="NAME"/>
-    <field labelOnTop="0" name="NAME_ALT"/>
-    <field labelOnTop="0" name="NAME_AR"/>
-    <field labelOnTop="0" name="NAME_BN"/>
-    <field labelOnTop="0" name="NAME_CIAWF"/>
-    <field labelOnTop="0" name="NAME_DE"/>
-    <field labelOnTop="0" name="NAME_EL"/>
-    <field labelOnTop="0" name="NAME_EN"/>
-    <field labelOnTop="0" name="NAME_ES"/>
-    <field labelOnTop="0" name="NAME_FR"/>
-    <field labelOnTop="0" name="NAME_HI"/>
-    <field labelOnTop="0" name="NAME_HU"/>
-    <field labelOnTop="0" name="NAME_ID"/>
-    <field labelOnTop="0" name="NAME_IT"/>
-    <field labelOnTop="0" name="NAME_JA"/>
-    <field labelOnTop="0" name="NAME_KO"/>
-    <field labelOnTop="0" name="NAME_LEN"/>
-    <field labelOnTop="0" name="NAME_LONG"/>
-    <field labelOnTop="0" name="NAME_NL"/>
-    <field labelOnTop="0" name="NAME_PL"/>
-    <field labelOnTop="0" name="NAME_PT"/>
-    <field labelOnTop="0" name="NAME_RU"/>
-    <field labelOnTop="0" name="NAME_SORT"/>
-    <field labelOnTop="0" name="NAME_SV"/>
-    <field labelOnTop="0" name="NAME_TR"/>
-    <field labelOnTop="0" name="NAME_VI"/>
-    <field labelOnTop="0" name="NAME_ZH"/>
-    <field labelOnTop="0" name="NE_ID"/>
-    <field labelOnTop="0" name="NOTE_ADM0"/>
-    <field labelOnTop="0" name="NOTE_BRK"/>
-    <field labelOnTop="0" name="POP_EST"/>
-    <field labelOnTop="0" name="POP_RANK"/>
-    <field labelOnTop="0" name="POP_YEAR"/>
-    <field labelOnTop="0" name="POSTAL"/>
-    <field labelOnTop="0" name="REGION_UN"/>
-    <field labelOnTop="0" name="REGION_WB"/>
-    <field labelOnTop="0" name="SOVEREIGNT"/>
-    <field labelOnTop="0" name="SOV_A3"/>
-    <field labelOnTop="0" name="SUBREGION"/>
-    <field labelOnTop="0" name="SUBUNIT"/>
-    <field labelOnTop="0" name="SU_A3"/>
-    <field labelOnTop="0" name="SU_DIF"/>
-    <field labelOnTop="0" name="TINY"/>
-    <field labelOnTop="0" name="TYPE"/>
-    <field labelOnTop="0" name="UN_A3"/>
-    <field labelOnTop="0" name="WB_A2"/>
-    <field labelOnTop="0" name="WB_A3"/>
-    <field labelOnTop="0" name="WIKIDATAID"/>
-    <field labelOnTop="0" name="WIKIPEDIA"/>
-    <field labelOnTop="0" name="WOE_ID"/>
-    <field labelOnTop="0" name="WOE_ID_EH"/>
-    <field labelOnTop="0" name="WOE_NOTE"/>
-    <field labelOnTop="0" name="featurecla"/>
-    <field labelOnTop="0" name="fid"/>
-    <field labelOnTop="0" name="iso_a2"/>
-    <field labelOnTop="0" name="scalerank"/>
+    <field name="ABBREV" labelOnTop="0"/>
+    <field name="ABBREV_LEN" labelOnTop="0"/>
+    <field name="ADM0_A3" labelOnTop="0"/>
+    <field name="ADM0_A3_IS" labelOnTop="0"/>
+    <field name="ADM0_A3_UN" labelOnTop="0"/>
+    <field name="ADM0_A3_US" labelOnTop="0"/>
+    <field name="ADM0_A3_WB" labelOnTop="0"/>
+    <field name="ADM0_DIF" labelOnTop="0"/>
+    <field name="ADMIN" labelOnTop="0"/>
+    <field name="BRK_A3" labelOnTop="0"/>
+    <field name="BRK_DIFF" labelOnTop="0"/>
+    <field name="BRK_GROUP" labelOnTop="0"/>
+    <field name="BRK_NAME" labelOnTop="0"/>
+    <field name="CONTINENT" labelOnTop="0"/>
+    <field name="ECONOMY" labelOnTop="0"/>
+    <field name="FIPS_10_" labelOnTop="0"/>
+    <field name="FORMAL_EN" labelOnTop="0"/>
+    <field name="FORMAL_FR" labelOnTop="0"/>
+    <field name="GDP_MD_EST" labelOnTop="0"/>
+    <field name="GDP_YEAR" labelOnTop="0"/>
+    <field name="GEOUNIT" labelOnTop="0"/>
+    <field name="GEOU_DIF" labelOnTop="0"/>
+    <field name="GU_A3" labelOnTop="0"/>
+    <field name="HOMEPART" labelOnTop="0"/>
+    <field name="INCOME_GRP" labelOnTop="0"/>
+    <field name="ISO_A2" labelOnTop="0"/>
+    <field name="ISO_A3" labelOnTop="0"/>
+    <field name="ISO_A3_EH" labelOnTop="0"/>
+    <field name="ISO_N3" labelOnTop="0"/>
+    <field name="LABELRANK" labelOnTop="0"/>
+    <field name="LASTCENSUS" labelOnTop="0"/>
+    <field name="LEVEL" labelOnTop="0"/>
+    <field name="LONG_LEN" labelOnTop="0"/>
+    <field name="MAPCOLOR13" labelOnTop="0"/>
+    <field name="MAPCOLOR7" labelOnTop="0"/>
+    <field name="MAPCOLOR8" labelOnTop="0"/>
+    <field name="MAPCOLOR9" labelOnTop="0"/>
+    <field name="MAX_LABEL" labelOnTop="0"/>
+    <field name="MIN_LABEL" labelOnTop="0"/>
+    <field name="MIN_ZOOM" labelOnTop="0"/>
+    <field name="NAME" labelOnTop="0"/>
+    <field name="NAME_ALT" labelOnTop="0"/>
+    <field name="NAME_AR" labelOnTop="0"/>
+    <field name="NAME_BN" labelOnTop="0"/>
+    <field name="NAME_CIAWF" labelOnTop="0"/>
+    <field name="NAME_DE" labelOnTop="0"/>
+    <field name="NAME_EL" labelOnTop="0"/>
+    <field name="NAME_EN" labelOnTop="0"/>
+    <field name="NAME_ES" labelOnTop="0"/>
+    <field name="NAME_FR" labelOnTop="0"/>
+    <field name="NAME_HI" labelOnTop="0"/>
+    <field name="NAME_HU" labelOnTop="0"/>
+    <field name="NAME_ID" labelOnTop="0"/>
+    <field name="NAME_IT" labelOnTop="0"/>
+    <field name="NAME_JA" labelOnTop="0"/>
+    <field name="NAME_KO" labelOnTop="0"/>
+    <field name="NAME_LEN" labelOnTop="0"/>
+    <field name="NAME_LONG" labelOnTop="0"/>
+    <field name="NAME_NL" labelOnTop="0"/>
+    <field name="NAME_PL" labelOnTop="0"/>
+    <field name="NAME_PT" labelOnTop="0"/>
+    <field name="NAME_RU" labelOnTop="0"/>
+    <field name="NAME_SORT" labelOnTop="0"/>
+    <field name="NAME_SV" labelOnTop="0"/>
+    <field name="NAME_TR" labelOnTop="0"/>
+    <field name="NAME_VI" labelOnTop="0"/>
+    <field name="NAME_ZH" labelOnTop="0"/>
+    <field name="NE_ID" labelOnTop="0"/>
+    <field name="NOTE_ADM0" labelOnTop="0"/>
+    <field name="NOTE_BRK" labelOnTop="0"/>
+    <field name="POP_EST" labelOnTop="0"/>
+    <field name="POP_RANK" labelOnTop="0"/>
+    <field name="POP_YEAR" labelOnTop="0"/>
+    <field name="POSTAL" labelOnTop="0"/>
+    <field name="REGION_UN" labelOnTop="0"/>
+    <field name="REGION_WB" labelOnTop="0"/>
+    <field name="SOVEREIGNT" labelOnTop="0"/>
+    <field name="SOV_A3" labelOnTop="0"/>
+    <field name="SUBREGION" labelOnTop="0"/>
+    <field name="SUBUNIT" labelOnTop="0"/>
+    <field name="SU_A3" labelOnTop="0"/>
+    <field name="SU_DIF" labelOnTop="0"/>
+    <field name="TINY" labelOnTop="0"/>
+    <field name="TYPE" labelOnTop="0"/>
+    <field name="UN_A3" labelOnTop="0"/>
+    <field name="WB_A2" labelOnTop="0"/>
+    <field name="WB_A3" labelOnTop="0"/>
+    <field name="WIKIDATAID" labelOnTop="0"/>
+    <field name="WIKIPEDIA" labelOnTop="0"/>
+    <field name="WOE_ID" labelOnTop="0"/>
+    <field name="WOE_ID_EH" labelOnTop="0"/>
+    <field name="WOE_NOTE" labelOnTop="0"/>
+    <field name="featurecla" labelOnTop="0"/>
+    <field name="fid" labelOnTop="0"/>
+    <field name="iso_a2" labelOnTop="0"/>
+    <field name="scalerank" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
     <field name="FIPS_10_" reuseLastValue="0"/>


### PR DESCRIPTION
Resaved the files in another QGIS with Qt5, this time on actual Windows (in VirtualBox): The attributes are in **different order** than in my Qt6 build.
The other differences are not related to this "investigation".

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>

QGIS version | 3.34.10-Prizren | QGIS code revision | 113de9e1
-- | -- | -- | --
Qt version | 5.15.13
Python version | 3.12.5
GDAL/OGR version | 3.9.2
PROJ version | 9.4.0
EPSG Registry database version | v11.004 (2024-02-24)
GEOS version | 3.12.2-CAPI-1.18.2
SQLite version | 3.45.1
PDAL version | 2.6.3
PostgreSQL client version | 16.2
SpatiaLite version | 5.1.0
QWT version | 6.2.0
QScintilla2 version | 2.14.1
OS version | Windows 10 Version 2009
  |   |   |  
Active Python plugins
db_manager | 0.1.20
grassprovider | 2.12.99
MetaSearch | 0.3.6
processing | 2.12.99

</body></html>